### PR TITLE
add auto_select functionality

### DIFF
--- a/autoload/deoplete/init.vim
+++ b/autoload/deoplete/init.vim
@@ -85,6 +85,8 @@ function! deoplete#init#_variables() abort "{{{
         \ 'g:deoplete#omni_patterns', {})
   call deoplete#util#set_default(
         \ 'g:deoplete#_omni_patterns', {})
+  call deoplete#util#set_default(
+        \ 'g:deoplete#enable_auto_select', 0)
 
   " Initialize omni completion pattern. "{{{
   call deoplete#util#set_pattern(

--- a/autoload/deoplete/mappings.vim
+++ b/autoload/deoplete/mappings.vim
@@ -36,7 +36,7 @@ function! deoplete#mappings#_do_complete(context) abort "{{{
           \ deoplete#helpers#get_input('TextChangedI'), '\h\w*$') + 1,
           \ a:context.candidates)
   endif
-  return ''
+  return  pumvisible() && g:deoplete#enable_auto_select ? "\<Down>" : ''
 endfunction"}}}
 
 function! deoplete#mappings#manual_complete(...) abort "{{{

--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -111,6 +111,14 @@ g:deoplete#enable_smart_case
 
 		Default value is 'infercase'.
 
+					*g:deoplete#enable_auto_select*
+g:deoplete#enable_auto_select
+		When deoplete displays candidates, this option controls
+		whether deoplete selects the first candidate
+		automatically.
+
+		Default value is 0.
+
 				*g:deoplete#auto_completion_start_length*
 g:deoplete#auto_completion_start_length
 		This variable controls the number of the input completion


### PR DESCRIPTION
This change adds auto select functionality as in neocomplete. For some users, this is a desirable and intuitive behavior.
 
API is similar to neocomplete. Compared to neocomplete, this implementation is simple.