### PR TITLE
Restore user's completeopt setting

### DIFF
--- a/autoload/deoplete/handlers.vim
+++ b/autoload/deoplete/handlers.vim
@@ -72,15 +72,14 @@ function! s:completion_begin(event) abort "{{{
 endfunction"}}}
 
 function! s:on_insert_leave() abort "{{{
+  if exists('g:deoplete#_context.saved_completeopt')
+    let &completeopt = g:deoplete#_context.saved_completeopt
+  endif
   let g:deoplete#_context = {}
 endfunction"}}}
 
 function! s:complete_done() abort "{{{
   let g:deoplete#_context.position = getpos('.')
-  if exists('b:deoplete_saved_completeopt')
-    let &completeopt = b:deoplete_saved_completeopt
-    unlet b:deoplete_saved_completeopt
-  endif
 endfunction"}}}
 
 " vim: foldmethod=marker

--- a/autoload/deoplete/handlers.vim
+++ b/autoload/deoplete/handlers.vim
@@ -77,6 +77,10 @@ endfunction"}}}
 
 function! s:complete_done() abort "{{{
   let g:deoplete#_context.position = getpos('.')
+  if exists('b:deoplete_saved_completeopt')
+    let &completeopt = b:deoplete_saved_completeopt
+    unlet b:deoplete_saved_completeopt
+  endif
 endfunction"}}}
 
 " vim: foldmethod=marker

--- a/autoload/deoplete/handlers.vim
+++ b/autoload/deoplete/handlers.vim
@@ -51,8 +51,6 @@ function! s:completion_begin(event) abort "{{{
   " Save the previous position
   let g:deoplete#_context.position = context.position
 
-  call deoplete#mappings#_set_completeopt()
-
   " Call omni completion
   for filetype in context.filetypes
     for pattern in deoplete#util#convert2list(
@@ -63,6 +61,7 @@ function! s:completion_begin(event) abort "{{{
       if deoplete#util#is_eskk_convertion()
             \ || (pattern != '' && &l:omnifunc != ''
             \ && context.input =~# '\%('.pattern.'\)$')
+        call deoplete#mappings#_set_completeopt()
         call feedkeys("\<C-x>\<C-o>", 'n')
         return
       endif

--- a/autoload/deoplete/handlers.vim
+++ b/autoload/deoplete/handlers.vim
@@ -74,6 +74,7 @@ endfunction"}}}
 function! s:on_insert_leave() abort "{{{
   if exists('g:deoplete#_context.saved_completeopt')
     let &completeopt = g:deoplete#_context.saved_completeopt
+    unlet g:deoplete#_context.saved_completeopt
   endif
   let g:deoplete#_context = {}
 endfunction"}}}

--- a/autoload/deoplete/handlers.vim
+++ b/autoload/deoplete/handlers.vim
@@ -51,6 +51,8 @@ function! s:completion_begin(event) abort "{{{
   " Save the previous position
   let g:deoplete#_context.position = context.position
 
+  call deoplete#mappings#_set_completeopt()
+
   " Call omni completion
   for filetype in context.filetypes
     for pattern in deoplete#util#convert2list(
@@ -61,7 +63,6 @@ function! s:completion_begin(event) abort "{{{
       if deoplete#util#is_eskk_convertion()
             \ || (pattern != '' && &l:omnifunc != ''
             \ && context.input =~# '\%('.pattern.'\)$')
-        call deoplete#mappings#_set_completeopt()
         call feedkeys("\<C-x>\<C-o>", 'n')
         return
       endif

--- a/autoload/deoplete/handlers.vim
+++ b/autoload/deoplete/handlers.vim
@@ -79,6 +79,10 @@ function! s:on_insert_leave() abort "{{{
 endfunction"}}}
 
 function! s:complete_done() abort "{{{
+  if exists('g:deoplete#_context.saved_completeopt')
+    let &completeopt = g:deoplete#_context.saved_completeopt
+    unlet g:deoplete#_context.saved_completeopt
+  endif
   let g:deoplete#_context.position = getpos('.')
 endfunction"}}}
 

--- a/autoload/deoplete/init.vim
+++ b/autoload/deoplete/init.vim
@@ -49,7 +49,7 @@ function! deoplete#init#enable() abort "{{{
   endif
 
   if &completeopt !~# 'noinsert\|noselect'
-    let l:save_completeopt = &completeopt
+    let save_completeopt = &completeopt
     try
       set completeopt+=noselect
     catch
@@ -59,7 +59,7 @@ function! deoplete#init#enable() abort "{{{
             \ 'Please update neovim to latest version.')
       return
     finally
-      let &completeopt = l:save_completeopt
+      let &completeopt = save_completeopt
     endtry
   endif
 

--- a/autoload/deoplete/init.vim
+++ b/autoload/deoplete/init.vim
@@ -49,6 +49,7 @@ function! deoplete#init#enable() abort "{{{
   endif
 
   if &completeopt !~# 'noinsert\|noselect'
+    let l:save_completeopt = &completeopt
     try
       set completeopt+=noselect
     catch
@@ -57,6 +58,8 @@ function! deoplete#init#enable() abort "{{{
       call deoplete#util#print_error(
             \ 'Please update neovim to latest version.')
       return
+    finally
+      let &completeopt = l:save_completeopt
     endtry
   endif
 

--- a/autoload/deoplete/mappings.vim
+++ b/autoload/deoplete/mappings.vim
@@ -29,8 +29,6 @@ function! deoplete#mappings#_init() abort "{{{
 endfunction"}}}
 
 function! deoplete#mappings#_do_complete(context) abort "{{{
-  call deoplete#mappings#_set_completeopt()
-
   if b:changedtick == get(a:context, 'changedtick', -1)
     call complete(a:context.complete_position + 1, a:context.candidates)
   endif

--- a/autoload/deoplete/mappings.vim
+++ b/autoload/deoplete/mappings.vim
@@ -38,7 +38,11 @@ function! deoplete#mappings#_do_complete(context) abort "{{{
   return ''
 endfunction"}}}
 function! deoplete#mappings#_set_completeopt() abort "{{{
-  " Deoplete does not work if completeopt contains longest and menu options
+  " Deoplete does not work if completeopt contains longest and menu options.
+  if exists('b:deoplete_saved_completeopt')
+    return
+  endif
+  let b:deoplete_saved_completeopt = &completeopt
   set completeopt-=longest
   set completeopt+=menuone
   if &completeopt !~# 'noinsert\|noselect'

--- a/autoload/deoplete/mappings.vim
+++ b/autoload/deoplete/mappings.vim
@@ -39,10 +39,10 @@ function! deoplete#mappings#_do_complete(context) abort "{{{
 endfunction"}}}
 function! deoplete#mappings#_set_completeopt() abort "{{{
   " Deoplete does not work if completeopt contains longest and menu options.
-  if exists('b:deoplete_saved_completeopt')
+  if exists('g:deoplete#_context.saved_completeopt')
     return
   endif
-  let b:deoplete_saved_completeopt = &completeopt
+  let g:deoplete#_context.saved_completeopt = &completeopt
   set completeopt-=longest
   set completeopt+=menuone
   if &completeopt !~# 'noinsert\|noselect'

--- a/rplugin/python3/deoplete/__init__.py
+++ b/rplugin/python3/deoplete/__init__.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: __init__.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,13 +21,14 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import neovim
 import traceback
 
 from deoplete.deoplete import Deoplete
 from deoplete.util import error
+
 
 @neovim.plugin
 class DeopleteHandlers(object):
@@ -47,7 +48,7 @@ class DeopleteHandlers(object):
                 context)
         except Exception:
             for line in traceback.format_exc().splitlines():
-                 error(self.vim, line)
+                error(self.vim, line)
             error(self.vim,
                   'An error has occurred. Please execute :messages command.')
             candidates = []
@@ -69,5 +70,4 @@ class DeopleteHandlers(object):
             'call deoplete#mappings#_set_completeopt()')
         # Note: cannot use vim.feedkeys()
         self.vim.command(
-          'call feedkeys("\<Plug>(deoplete_start_complete)")')
-
+            'call feedkeys("\<Plug>(deoplete_start_complete)")')

--- a/rplugin/python3/deoplete/__init__.py
+++ b/rplugin/python3/deoplete/__init__.py
@@ -1,4 +1,4 @@
-# ============================================================================
+#=============================================================================
 # FILE: __init__.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,14 +21,13 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-# ============================================================================
+#=============================================================================
 
 import neovim
 import traceback
 
 from deoplete.deoplete import Deoplete
 from deoplete.util import error
-
 
 @neovim.plugin
 class DeopleteHandlers(object):
@@ -48,7 +47,7 @@ class DeopleteHandlers(object):
                 context)
         except Exception:
             for line in traceback.format_exc().splitlines():
-                error(self.vim, line)
+                 error(self.vim, line)
             error(self.vim,
                   'An error has occurred. Please execute :messages command.')
             candidates = []
@@ -70,4 +69,5 @@ class DeopleteHandlers(object):
             'call deoplete#mappings#_set_completeopt()')
         # Note: cannot use vim.feedkeys()
         self.vim.command(
-            'call feedkeys("\<Plug>(deoplete_start_complete)")')
+          'call feedkeys("\<Plug>(deoplete_start_complete)")')
+

--- a/rplugin/python3/deoplete/__init__.py
+++ b/rplugin/python3/deoplete/__init__.py
@@ -63,6 +63,10 @@ class DeopleteHandlers(object):
         var_context['candidates'] = candidates
         self.vim.vars['deoplete#_context'] = var_context
 
+        # Set (and store) current &completeopt setting.  This cannot be done
+        # (currently) from the deoplete_start_complete mapping's function.
+        self.vim.command(
+            'call deoplete#mappings#_set_completeopt()')
         # Note: cannot use vim.feedkeys()
         self.vim.command(
           'call feedkeys("\<Plug>(deoplete_start_complete)")')


### PR DESCRIPTION
The buffer's completeopt setting should get restored after deoplete is
done.

This is required when using deoplete on demand.