### PR TITLE
autopep8

### DIFF
--- a/rplugin/python3/deoplete/__init__.py
+++ b/rplugin/python3/deoplete/__init__.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: __init__.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,7 +21,7 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import neovim
 import traceback
@@ -29,8 +29,10 @@ import traceback
 from deoplete.deoplete import Deoplete
 from deoplete.util import error
 
+
 @neovim.plugin
 class DeopleteHandlers(object):
+
     def __init__(self, vim):
         self.vim = vim
 
@@ -47,7 +49,7 @@ class DeopleteHandlers(object):
                 context)
         except Exception:
             for line in traceback.format_exc().splitlines():
-                 error(self.vim, line)
+                error(self.vim, line)
             error(self.vim,
                   'An error has occurred. Please execute :messages command.')
             candidates = []
@@ -69,5 +71,4 @@ class DeopleteHandlers(object):
             'call deoplete#mappings#_set_completeopt()')
         # Note: cannot use vim.feedkeys()
         self.vim.command(
-          'call feedkeys("\<Plug>(deoplete_start_complete)")')
-
+            'call feedkeys("\<Plug>(deoplete_start_complete)")')

--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: deoplete.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,7 +21,7 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import re
 import importlib.machinery
@@ -38,7 +38,9 @@ deoplete.filters  # silence pyflakes
 
 # from deoplete.util import debug
 
+
 class Deoplete(object):
+
     def __init__(self, vim):
         self.vim = vim
         self.filters = {}
@@ -49,8 +51,8 @@ class Deoplete(object):
         # Load sources from runtimepath
         for path in globruntime(self.vim,
                                 'rplugin/python3/deoplete/sources/base.py'
-                    ) + globruntime(self.vim,
-                                    'rplugin/python3/deoplete/sources/*.py'):
+                                ) + globruntime(self.vim,
+                                                'rplugin/python3/deoplete/sources/*.py'):
             name = os.path.basename(path)[: -3]
             source = importlib.machinery.SourceFileLoader(
                 'deoplete.sources.' + name, path).load_module()
@@ -62,8 +64,8 @@ class Deoplete(object):
         # Load filters from runtimepath
         for path in globruntime(self.vim,
                                 'rplugin/python3/deoplete/filters/base.py'
-                    ) + globruntime(self.vim,
-                                    'rplugin/python3/deoplete/filters/*.py'):
+                                ) + globruntime(self.vim,
+                                                'rplugin/python3/deoplete/filters/*.py'):
             name = os.path.basename(path)[: -3]
             filter = importlib.machinery.SourceFileLoader(
                 'deoplete.filters.' + name, path).load_module()
@@ -75,11 +77,11 @@ class Deoplete(object):
         # Skip completion
         if (self.vim.eval('&l:completefunc') != ''
                 and 'nofile' in self.vim.eval('&l:buftype')
-                ) or (context['event'] != 'Manual' and
-                    get_simple_buffer_config(
-                        self.vim,
-                        'b:deoplete_disable_auto_complete',
-                        'g:deoplete#disable_auto_complete')):
+            ) or (context['event'] != 'Manual' and
+                  get_simple_buffer_config(
+                self.vim,
+                'b:deoplete_disable_auto_complete',
+                'g:deoplete#disable_auto_complete')):
             return (-1, [])
 
         if self.vim.eval('&runtimepath') != self.runtimepath:
@@ -101,17 +103,17 @@ class Deoplete(object):
         start_length = self.vim.eval(
             'g:deoplete#auto_completion_start_length')
         for source_name, source in sorted(self.sources.items(),
-                key=lambda x: x[1].rank, reverse=True):
+                                          key=lambda x: x[1].rank, reverse=True):
             if (sources and not source_name in sources
-                    ) or (source.filetypes and
-                        not context['filetype'] in source.filetypes):
+                ) or (source.filetypes and
+                      not context['filetype'] in source.filetypes):
                 continue
             cont = copy.deepcopy(context)
             charpos = source.get_complete_position(cont)
             if charpos >= 0 and source.is_bytepos:
                 charpos = bytepos2charpos(
                     self.vim, cont['input'], charpos)
-            cont['complete_str'] = cont['input'][charpos :]
+            cont['complete_str'] = cont['input'][charpos:]
             cont['complete_position'] = charpos2bytepos(
                 self.vim, cont['input'], charpos)
             # debug(self.vim, source.rank)
@@ -129,7 +131,7 @@ class Deoplete(object):
 
             if charpos < 0 or (cont['event'] != 'Manual'
                                and len(cont['complete_str'])
-                                     < min_pattern_length):
+                               < min_pattern_length):
                 # Skip
                 continue
             results.append({
@@ -147,8 +149,8 @@ class Deoplete(object):
             if context['candidates'] and type(
                     context['candidates'][0]) == type(''):
                 # Convert to dict
-                context['candidates'] = [{ 'word': x }
-                                         for x in context['candidates'] ]
+                context['candidates'] = [{'word': x}
+                                         for x in context['candidates']]
 
             matchers = get_custom(self.vim, source.name).get(
                 'matchers', source.matchers)
@@ -202,7 +204,7 @@ class Deoplete(object):
                 candidates += context['candidates']
                 continue
             prefix = context['input'][context['complete_position']
-                                      - complete_position :]
+                                      - complete_position:]
 
             context['complete_position'] = complete_position
             context['complete_str'] = prefix
@@ -213,4 +215,3 @@ class Deoplete(object):
             candidates += context['candidates']
         # debug(self.vim, candidates)
         return (complete_position, candidates)
-

--- a/rplugin/python3/deoplete/filters/base.py
+++ b/rplugin/python3/deoplete/filters/base.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: base.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,11 +21,13 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 from abc import abstractmethod
 
+
 class Base(object):
+
     def __init__(self, vim):
         self.vim = vim
         self.name = 'base'

--- a/rplugin/python3/deoplete/filters/converter_remove_overlap.py
+++ b/rplugin/python3/deoplete/filters/converter_remove_overlap.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: converter_remove_overlap.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,7 +21,7 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import re
 from .base import Base

--- a/rplugin/python3/deoplete/filters/matcher_fuzzy.py
+++ b/rplugin/python3/deoplete/filters/matcher_fuzzy.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: matcher_fuzzy.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,12 +21,14 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import re
 from .base import Base
 
+
 class Filter(Base):
+
     def __init__(self, vim):
         Base.__init__(self, vim)
 
@@ -42,11 +44,11 @@ class Filter(Base):
         return [x for x in context['candidates']
                 if len(x['word']) > input_len and p.match(x['word'].lower())
                 ] if context['ignorecase'] \
-                  else [x for x in context['candidates']
-                        if len(x['word']) > input_len and p.match(x['word'])]
+            else [x for x in context['candidates']
+                  if len(x['word']) > input_len and p.match(x['word'])]
+
 
 def fuzzy_escape(string):
     # Escape string for python regexp.
     string = re.sub(r'([a-zA-Z0-9_])', r'\1.*', re.escape(string))
     return string
-

--- a/rplugin/python3/deoplete/filters/matcher_head.py
+++ b/rplugin/python3/deoplete/filters/matcher_head.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: matcher_head.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,11 +21,13 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 from .base import Base
 
+
 class Filter(Base):
+
     def __init__(self, vim):
         Base.__init__(self, vim)
 
@@ -39,9 +41,8 @@ class Filter(Base):
         input_len = len(complete_str)
         return [x for x in context['candidates']
                 if len(x['word']) > input_len
-                   and x['word'].lower().startswith(complete_str)
+                and x['word'].lower().startswith(complete_str)
                 ] if context['ignorecase'] \
-                  else [x for x in context['candidates']
-                        if len(x['word']) > input_len
-                        and x['word'].startswith(complete_str)]
-
+            else [x for x in context['candidates']
+                  if len(x['word']) > input_len
+                  and x['word'].startswith(complete_str)]

--- a/rplugin/python3/deoplete/filters/sorter_rank.py
+++ b/rplugin/python3/deoplete/filters/sorter_rank.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: sorter_rank.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,11 +21,13 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 from .base import Base
 
+
 class Filter(Base):
+
     def __init__(self, vim):
         Base.__init__(self, vim)
 
@@ -36,6 +38,5 @@ class Filter(Base):
         complete_str = context['complete_str'].lower()
         input_len = len(complete_str)
         return sorted(context['candidates'],
-            key=lambda x: abs(x['word'].lower().find(
-                complete_str, 0, input_len)))
-
+                      key=lambda x: abs(x['word'].lower().find(
+                          complete_str, 0, input_len)))

--- a/rplugin/python3/deoplete/sources/base.py
+++ b/rplugin/python3/deoplete/sources/base.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: base.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,12 +21,14 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import re
 from abc import abstractmethod
 
+
 class Base(object):
+
     def __init__(self, vim):
         self.vim = vim
         self.name = 'base'
@@ -41,10 +43,10 @@ class Base(object):
         self.rank = 100
 
     def get_complete_position(self, context):
-        m = re.search('('+context['keyword_patterns']+')$', context['input'])
+        m = re.search(
+            '(' + context['keyword_patterns'] + ')$', context['input'])
         return m.start() if m else -1
 
     @abstractmethod
     def gather_candidate(self, context):
         pass
-

--- a/rplugin/python3/deoplete/sources/buffer.py
+++ b/rplugin/python3/deoplete/sources/buffer.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: buffer.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,14 +21,16 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import re
 import operator
 import functools
 from .base import Base
 
+
 class Source(Base):
+
     def __init__(self, vim):
         Base.__init__(self, vim)
 
@@ -46,7 +48,7 @@ class Source(Base):
             self.buffers[self.vim.current.buffer.number][
                 'candidates'] += functools.reduce(operator.add, [
                     p.findall(x) for x in self.vim.current.buffer[
-                        max([0, line-500]) : line+500]
+                        max([0, line - 500]): line + 500]
                 ])
         else:
             self.buffers[self.vim.current.buffer.number] = {
@@ -56,8 +58,7 @@ class Source(Base):
                 ]),
             }
 
-        return [{ 'word': x } for x in
+        return [{'word': x} for x in
                 functools.reduce(operator.add, [
-                     x['candidates'] for x in self.buffers.values()
-                     if x['filetype'] in context['filetypes']])]
-
+                    x['candidates'] for x in self.buffers.values()
+                    if x['filetype'] in context['filetypes']])]

--- a/rplugin/python3/deoplete/sources/dictionary.py
+++ b/rplugin/python3/deoplete/sources/dictionary.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: dictionary.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,7 +21,7 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import re
 from os.path import getmtime, exists
@@ -30,7 +30,9 @@ from .base import Base
 
 DictCacheItem = namedtuple('DictCacheItem', 'mtime candidates')
 
+
 class Source(Base):
+
     def __init__(self, vim):
         Base.__init__(self, vim)
 
@@ -53,7 +55,8 @@ class Source(Base):
                 self.cache[filename] = DictCacheItem(mtime, new_candidates)
             else:
                 candidates += self.cache[filename].candidates
-        return [{ 'word': x } for x in candidates]
+        return [{'word': x} for x in candidates]
+
 
 def parse_dictionary(f, keyword_patterns):
     p = re.compile(keyword_patterns)
@@ -63,6 +66,6 @@ def parse_dictionary(f, keyword_patterns):
         candidates += p.findall(l)
     return list(set(candidates))
 
+
 def get_dictionaries(vim, filetype):
     return vim.eval('&l:dictionary').split(',')
-

--- a/rplugin/python3/deoplete/sources/file.py
+++ b/rplugin/python3/deoplete/sources/file.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: file.py
 # AUTHOR: Felipe Morales <hel.sheep at gmail.com>
 #         Shougo Matsushita <Shougo.Matsu at gmail.com>
@@ -22,12 +22,13 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import os
 from os.path import exists, dirname
 from glob import glob
 from .base import Base
+
 
 def longest_path_that_exists(input_str):
     data = input_str.split(' ')
@@ -37,7 +38,9 @@ def longest_path_that_exists(input_str):
         return sorted(existing_paths)[-1]
     return None
 
+
 class Source(Base):
+
     def __init__(self, vim):
         Base.__init__(self, vim)
 
@@ -52,9 +55,8 @@ class Source(Base):
 
     def gather_candidates(self, context):
         dirs = [x for x in glob(context['complete_str'] + '*')
-                      if os.path.isdir(x)]
+                if os.path.isdir(x)]
         files = [x for x in glob(context['complete_str'] + '*')
-                      if not os.path.isdir(x)]
-        return [{ 'word': x, 'abbr': x + '/' } for x in sorted(dirs)
-                ] + [{ 'word': x } for x in sorted(files)]
-
+                 if not os.path.isdir(x)]
+        return [{'word': x, 'abbr': x + '/'} for x in sorted(dirs)
+                ] + [{'word': x} for x in sorted(files)]

--- a/rplugin/python3/deoplete/sources/member.py
+++ b/rplugin/python3/deoplete/sources/member.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: member.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,7 +21,7 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import re
 import operator
@@ -30,7 +30,9 @@ from deoplete.util import \
     get_default_buffer_config, convert2list
 from .base import Base
 
+
 class Source(Base):
+
     def __init__(self, vim):
         Base.__init__(self, vim)
 
@@ -51,7 +53,7 @@ class Source(Base):
                     'g:deoplete#member#prefix_patterns',
                     'g:deoplete#member#_prefix_patterns')):
             m = re.search(self.object_pattern + prefix_pattern + r'\w*$',
-                        context['input'])
+                          context['input'])
             if m is None or prefix_pattern == '':
                 continue
             self.prefix = re.sub(r'\w*$', '', m.group(0))
@@ -61,8 +63,7 @@ class Source(Base):
     def gather_candidates(self, context):
         p = re.compile(r'(?<=' + re.escape(self.prefix) + r')\w+(?:\(\)?)?')
 
-        return [{ 'word': x } for x in
+        return [{'word': x} for x in
                 functools.reduce(operator.add, [
-                     p.findall(x) for x in self.vim.current.buffer
-                     ])]
-
+                    p.findall(x) for x in self.vim.current.buffer
+                ])]

--- a/rplugin/python3/deoplete/sources/omni.py
+++ b/rplugin/python3/deoplete/sources/omni.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: omni.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,14 +21,16 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import re
 from .base import Base
 from deoplete.util import \
     get_default_buffer_config, error, convert2list
 
+
 class Source(Base):
+
     def __init__(self, vim):
         Base.__init__(self, vim)
 
@@ -49,7 +51,7 @@ class Source(Base):
                 'g:deoplete#omni#input_patterns',
                 'g:deoplete#omni#_input_patterns')):
 
-            m = re.search('('+input_pattern+')$', context['input'])
+            m = re.search('(' + input_pattern + ')$', context['input'])
             if m is None or input_pattern == '':
                 continue
 
@@ -58,7 +60,7 @@ class Source(Base):
                     self.vim.eval('&l:omnifunc'), 1, '')
             except:
                 error(self.vim, 'Error occurred calling omnifunction: '
-                    + self.vim.eval('&l:omnifunc'))
+                      + self.vim.eval('&l:omnifunc'))
 
                 return -1
             return complete_pos
@@ -70,9 +72,8 @@ class Source(Base):
                 self.vim.eval('&l:omnifunc'), 0, context['complete_str'])
         except:
             error(self.vim, 'Error occurred calling omnifunction: '
-                + self.vim.eval('&l:omnifunc'))
+                  + self.vim.eval('&l:omnifunc'))
 
             candidates = []
 
         return candidates
-

--- a/rplugin/python3/deoplete/sources/tag.py
+++ b/rplugin/python3/deoplete/sources/tag.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: tag.py
 # AUTHOR: Felipe Morales <hel.sheep at gmail.com>
 #         Shougo Matsushita <Shougo.Matsu at gmail.com>
@@ -22,7 +22,7 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import re
 from os.path import getmtime, exists
@@ -31,7 +31,9 @@ from .base import Base
 
 TagsCacheItem = namedtuple('TagsCacheItem', 'mtime candidates')
 
+
 class Source(Base):
+
     def __init__(self, vim):
         Base.__init__(self, vim)
 
@@ -55,7 +57,8 @@ class Source(Base):
                 self.cache[filename] = TagsCacheItem(mtime, new_candidates)
             else:
                 candidates += self.cache[filename].candidates
-        return [{ 'word': x } for x in candidates]
+        return [{'word': x} for x in candidates]
+
 
 def parse_tags(f):
     p = re.compile('^[a-zA-Z_]\w*(?=\t)')
@@ -64,4 +67,3 @@ def parse_tags(f):
     for l in f.readlines():
         candidates += p.findall(l)
     return list(set(candidates))
-

--- a/rplugin/python3/deoplete/tests/test_filter.py
+++ b/rplugin/python3/deoplete/tests/test_filter.py
@@ -3,7 +3,9 @@ from nose.tools import eq_
 from deoplete.filters.matcher_fuzzy import fuzzy_escape
 from deoplete.filters.converter_remove_overlap import overlap_length
 
+
 class FilterTestCase(TestCase):
+
     def test_fuzzy_escapse(self):
         eq_(fuzzy_escape('foo'), 'f.*o.*o.*')
 
@@ -13,4 +15,3 @@ class FilterTestCase(TestCase):
         eq_(overlap_length('foob', 'baz'), 1)
         eq_(overlap_length('foobar', 'foobar'), 6)
         eq_(overlap_length('тест', 'ст'), len('ст'))
-

--- a/rplugin/python3/deoplete/util.py
+++ b/rplugin/python3/deoplete/util.py
@@ -1,4 +1,4 @@
-#=============================================================================
+# ============================================================================
 # FILE: util.py
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # License: MIT license  {{{
@@ -21,54 +21,67 @@
 #     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 #     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # }}}
-#=============================================================================
+# ============================================================================
 
 import json
+
 
 def get_buffer_config(vim, context, buffer_var, user_var, default_var):
     return vim.call('deoplete#util#get_buffer_config',
                     context['filetype'],
                     buffer_var, user_var, default_var)
 
+
 def get_default_buffer_config(vim, context, buffer_var, user_var, default_var):
     return vim.call('deoplete#util#get_default_buffer_config',
                     context['filetype'],
                     buffer_var, user_var, default_var)
 
+
 def get_simple_buffer_config(vim, buffer_var, user_var):
     return vim.call('deoplete#util#get_simple_buffer_config',
                     buffer_var, user_var)
 
+
 def set_pattern(vim, variable, keys, pattern):
     return vim.call('deoplete#util#set_pattern', variable, keys, pattern)
+
 
 def set_list(vim, variable, keys, list):
     return vim.call('deoplete#util#set_pattern', variable, keys, list)
 
+
 def set_default(vim, var, val):
     return vim.call('deoplete#util#set_default', var, val)
+
 
 def convert2list(expr):
     return (expr if isinstance(expr, list) else [expr])
 
+
 def globruntime(vim, path):
     return vim.funcs.globpath(vim.eval('&runtimepath'), path, 1, 1)
+
 
 def debug(vim, msg):
     vim.command('echomsg string(\'' + escape(json.dumps(msg)) + '\')')
 
+
 def error(vim, msg):
     vim.call('deoplete#util#print_error', msg)
+
 
 def escape(expr):
     return expr.replace("'", "''")
 
+
 def charpos2bytepos(vim, input, pos):
     return len(bytes(input[: pos], vim.eval('&encoding')))
+
 
 def bytepos2charpos(vim, input, pos):
     return len(vim.funcs.substitute(input[: pos], '.', 'x', 'g'))
 
+
 def get_custom(vim, source_name):
     return vim.call('deoplete#custom#get', source_name)
-


### PR DESCRIPTION
There are still some left according to `pep8 **/*.py`, most of theme because of the file headers:
```
rplugin/python3/deoplete/deoplete.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/deoplete.py:24:1: E265 block comment should start with '# '
rplugin/python3/deoplete/deoplete.py:33:1: E402 module level import not at top of file
rplugin/python3/deoplete/deoplete.py:36:1: E402 module level import not at top of file
rplugin/python3/deoplete/deoplete.py:55:80: E501 line too long (89 > 79 characters)
rplugin/python3/deoplete/deoplete.py:59:46: E713 test for membership should be 'not in'
rplugin/python3/deoplete/deoplete.py:68:80: E501 line too long (89 > 79 characters)
rplugin/python3/deoplete/deoplete.py:72:46: E713 test for membership should be 'not in'
rplugin/python3/deoplete/deoplete.py:79:17: W503 line break before binary operator
rplugin/python3/deoplete/deoplete.py:106:80: E501 line too long (81 > 79 characters)
rplugin/python3/deoplete/deoplete.py:107:29: E713 test for membership should be 'not in'
rplugin/python3/deoplete/deoplete.py:133:32: W503 line break before binary operator
rplugin/python3/deoplete/deoplete.py:134:32: W503 line break before binary operator
rplugin/python3/deoplete/deoplete.py:150:47: E721 do not compare types, use 'isinstance()'
rplugin/python3/deoplete/deoplete.py:207:39: W503 line break before binary operator
rplugin/python3/deoplete/filters/base.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/filters/base.py:24:1: E265 block comment should start with '# '
rplugin/python3/deoplete/filters/matcher_fuzzy.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/filters/matcher_fuzzy.py:24:1: E265 block comment should start with '# '
rplugin/python3/deoplete/filters/matcher_head.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/filters/matcher_head.py:24:1: E265 block comment should start with '# '
rplugin/python3/deoplete/filters/matcher_head.py:44:17: W503 line break before binary operator
rplugin/python3/deoplete/filters/matcher_head.py:48:19: W503 line break before binary operator
rplugin/python3/deoplete/filters/sorter_rank.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/filters/sorter_rank.py:24:1: E265 block comment should start with '# '
rplugin/python3/deoplete/__init__.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/__init__.py:24:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/base.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/base.py:24:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/buffer.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/buffer.py:24:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/dictionary.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/dictionary.py:24:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/file.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/file.py:25:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/member.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/member.py:24:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/omni.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/omni.py:24:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/omni.py:63:23: W503 line break before binary operator
rplugin/python3/deoplete/sources/omni.py:75:19: W503 line break before binary operator
rplugin/python3/deoplete/sources/tag.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/tag.py:25:1: E265 block comment should start with '# '
rplugin/python3/deoplete/sources/tag.py:49:17: W503 line break before binary operator
rplugin/python3/deoplete/sources/tag.py:50:17: W503 line break before binary operator
rplugin/python3/deoplete/util.py:1:1: E265 block comment should start with '# '
rplugin/python3/deoplete/util.py:24:1: E265 block comment should start with '# '
```