### PR TITLE
makes the popup respect the disable flags

### DIFF
--- a/autoload/deoplete/handlers.vim
+++ b/autoload/deoplete/handlers.vim
@@ -38,6 +38,8 @@ function! s:completion_begin(event) abort "{{{
 
   " Skip
   if &paste
+        \ || (b:deoplete_disable_auto_complete != 0)
+        \ || (g:deoplete#disable_auto_complete != 0)
         \ || (context.position ==# get(g:deoplete#_context, 'position', [])
         \      && (get(v:completed_item, 'word', '') == ''
         \         || empty(filter(copy(g:deoplete#delimiters),


### PR DESCRIPTION
While attempting to disable deoplete in some cases I found that setting the disable flags didn't actually prevent the popupmenu. 