### PR TITLE
Added a debug mode to prevent uncommented debug statements

### DIFF
--- a/plugin/deoplete.vim
+++ b/plugin/deoplete.vim
@@ -36,6 +36,11 @@ if get(g:, 'deoplete#enable_at_startup', 0)
   augroup deoplete
     autocmd CursorHold,InsertEnter * call deoplete#init#enable()
   augroup END
-endif"}}}
+endif
+
+if !exists("g:deoplete#debug")
+  let g:deoplete#debug = 1
+endif
+"}}}
 
 " vim: foldmethod=marker

--- a/rplugin/python3/deoplete/util.py
+++ b/rplugin/python3/deoplete/util.py
@@ -57,7 +57,10 @@ def globruntime(vim, path):
 
 
 def debug(vim, expr):
-    vim.command('echomsg string(\'' + escape(json.dumps(expr)) + '\')')
+    if vim.vars['deoplete#debug']:
+        vim.command('echomsg string(\'' + escape(json.dumps(expr)) + '\')')
+    else:
+        error(vim, "not in debug mode, but debug called")
 
 
 def error(vim, msg):


### PR DESCRIPTION
If debug is called but debug mode isn't set, an error is displayed. This
should help prevent uncommented debug statements.