### PR TITLE
Save 'completeopt' and restore it when leaving insert mode

### DIFF
--- a/autoload/deoplete/handlers.vim
+++ b/autoload/deoplete/handlers.vim
@@ -101,6 +101,10 @@ function! s:is_skip(event, context) abort "{{{
 endfunction"}}}
 
 function! s:on_insert_leave() abort "{{{
+  if exists('g:deoplete#_saved_completeopt')
+    let &completeopt = g:deoplete#_saved_completeopt
+    unlet g:deoplete#_saved_completeopt
+  endif
   let g:deoplete#_context = {}
 endfunction"}}}
 

--- a/autoload/deoplete/mappings.vim
+++ b/autoload/deoplete/mappings.vim
@@ -38,6 +38,10 @@ function! deoplete#mappings#_do_complete(context) abort "{{{
   return ''
 endfunction"}}}
 function! deoplete#mappings#_set_completeopt() abort "{{{
+  if exists('g:deoplete#_saved_completeopt')
+    return
+  endif
+  let g:deoplete#_saved_completeopt = &completeopt
   set completeopt-=longest
   set completeopt+=menuone
   set completeopt-=menu


### PR DESCRIPTION
This follows up on https://github.com/Shougo/deoplete.nvim/pull/79, but
does only restore it when leaving insert mode (not on CompleteDone).

This does not use `g:deoplete#_context` for it, because that would
require to pass it through in `completion_begin` and keep it in
`deoplete#deoplete#init#_context`.