### PR TITLE
Do not call 'deoplete#mappings#_set_completeopt' in manual mode

### DIFF
--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -79,9 +79,12 @@ class Deoplete(object):
             'event': context['event'],
         }
 
-        # Set (and store) current &completeopt setting.  This cannot be done
-        # (currently) from the deoplete_start_complete mapping's function.
-        self.__vim.call('deoplete#mappings#_set_completeopt')
+        if context['event'] != 'Manual':
+            # Set (and store) current &completeopt setting.  This cannot be
+            # done (currently) from the deoplete_start_complete mapping's
+            # function.
+            self.__vim.call('deoplete#mappings#_set_completeopt')
+
         # Note: cannot use vim.feedkeys()
         self.__vim.command(
             'call feedkeys("\<Plug>(deoplete_start_complete)")')


### PR DESCRIPTION
Changing `'completeopt'` seems to be necessary only for the
auto-completion mode?!