### PR TITLE
Fix always call vim.vars even if setting is false

### DIFF
--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -162,6 +162,10 @@ g:deoplete#enable_debug
 g:deoplete#enable_profile
 		It enables deoplete profile mode.
 		If it is 1, deoplete will print the time information.
+		Must be set in init.vim before to start the Neovim.
+		Does not support command line.
+
+		Default value: 0
 
 				*g:deoplete#delimiters*
 g:deoplete#delimiters

--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -49,6 +49,7 @@ class Deoplete(object):
         self.__filters = {}
         self.__sources = {}
         self.__runtimepath = ''
+        self.__profile_flag = None
         self.__profile_start = 0
 
     def completion_begin(self, context):
@@ -256,13 +257,20 @@ class Deoplete(object):
         deoplete.util.debug(self.__vim, expr)
 
     def profile_start(self, name):
-        if self.__vim.vars['deoplete#enable_profile']:
+        if self.__profile_flag is 0:
+            return
+        elif self.__profile_flag is None:
+            if self.__vim.vars['deoplete#enable_profile']:
+                self.__profile_flag = 1
+            else:
+                self.__profile_flag = 0
+        elif self.__profile_flag:
             self.__vim.command(
                 'echomsg \'profile start: {0}\''.format(name))
             self.__profile_start = time.clock()
 
     def profile_end(self, name):
-        if self.__vim.vars['deoplete#enable_profile']:
+        if self.__profile_start:
             self.__vim.command(
                 'echomsg \'profile end  : {0}, time={1}\''.format(
                     name, time.clock() - self.__profile_start))


### PR DESCRIPTION
Always get `g:deoplete#enable_profile` value if not set it flag
- ~~Also gives priority to the `g:deoplete#enable_debug` flag ahead~~

and support only once to get the this flag.

Before and after logs here.

- before: https://gist.github.com/zchee/681c113554f5022ce94d#file-before-log
- after: https://gist.github.com/zchee/681c113554f5022ce94d#file-after-log

===

Edit:
- Parse `g:deoplete#enable_profile` only. `g:deoplete#enable_debug` for debug echomsg.