### PR TITLE
Use `.endswith` with disabled_syntaxes check

### DIFF
--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -311,8 +311,8 @@ class Deoplete(object):
                        not (min_pattern_length <=
                             len(context['complete_str']) <=
                             max_pattern_length))
-        return (disabled_syntaxes and
-                context['syntax_name'] in disabled_syntaxes) or skip_length
+        return skip_length or any(context['syntax_name'].endswith(s)
+                                  for s in disabled_syntaxes)
 
     def check_position(self, pos):
         return self.__vim.funcs.mode(


### PR DESCRIPTION
It seems to be a common habit to also ignore `gitcommitComment` for
`Comment`?!

Otherwise, we could have support for globbing here, i.e. only `*Comment`
would also ignore `gitcommitComment`.