### PR TITLE
Use Python's logging facility

### DIFF
--- a/autoload/deoplete/util.vim
+++ b/autoload/deoplete/util.vim
@@ -138,4 +138,22 @@ function! deoplete#util#get_syn_name() abort "{{{
         \          col('.')-1 : col('.'), 1)), 'name') : ''
 endfunction"}}}
 
+function! deoplete#util#neovim_version() abort "{{{
+  redir => v
+  silent version
+  redir END
+  return split(v, '\n')[0]
+endfunction"}}}
+
+function! deoplete#util#enable_logging(level, logfile) abort "{{{
+  if !deoplete#init#is_enabled()
+    " Enable to allow logging before completions start
+    call deoplete#init#enable()
+  endif
+
+  call rpcrequest(g:deoplete#_channel_id,
+        \ 'deoplete_enable_logging',
+        \ a:level,
+        \ a:logfile)
+endfunction"}}}
 " vim: foldmethod=marker

--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -341,6 +341,14 @@ deoplete#custom#set({source-name}, {option-name}, {value})
 		call deoplete#custom#set('_',
 		\ 'disabled_syntaxes', ['Comment', 'String'])
 <
+					*deoplete#util#enable_logging()*
+deoplete#util#enable_logging({level}, {logfile})
+		Enable logging for debugging purposes.
+		Set {level} to DEBUG, INFO, WARNING, ERROR, or CRITICAL.
+		{logfile} is the file where log messages are written.
+		Messages are appended to this file.  Each log session will
+		start with "--- Deoplete Log Start ---".
+
 ------------------------------------------------------------------------------
 KEY MAPPINGS 					*deoplete-key-mappings*
 
@@ -440,7 +448,7 @@ FILTERS						*deoplete-filters*
 
 					*deoplete-filter-matcher_default*
 Default matchers: ['matcher_length', 'matcher_fuzzy']
-	
+
 	You can change it by |deoplete#custom#set()|.
 
 					*deoplete-filter-sorter_default*

--- a/rplugin/python3/deoplete/__init__.py
+++ b/rplugin/python3/deoplete/__init__.py
@@ -6,6 +6,7 @@
 
 import neovim
 
+from deoplete import logger
 from deoplete.deoplete import Deoplete
 
 
@@ -19,6 +20,11 @@ class DeopleteHandlers(object):
     def init_python(self, args):
         self.__deoplete = Deoplete(self.__vim)
         self.__vim.vars['deoplete#_channel_id'] = self.__vim.channel_id
+
+    @neovim.rpc_export('deoplete_enable_logging', sync=True)
+    def enable_logging(self, level, logfile):
+        logger.setup(self.__vim, level, logfile)
+        self.__deoplete.debug_enabled = True
 
     @neovim.rpc_export('deoplete_auto_completion_begin')
     def completion_begin(self, context):

--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -11,6 +11,7 @@ from deoplete.util import \
 import deoplete.sources
 import deoplete.filters
 import deoplete.util
+from deoplete import logger
 
 import re
 import importlib.machinery
@@ -23,7 +24,7 @@ deoplete.sources  # silence pyflakes
 deoplete.filters  # silence pyflakes
 
 
-class Deoplete(object):
+class Deoplete(logger.LoggingMixin):
 
     def __init__(self, vim):
         self.__vim = vim
@@ -32,6 +33,7 @@ class Deoplete(object):
         self.__runtimepath = ''
         self.__profile_flag = None
         self.__profile_start = 0
+        self.__logname = 'core'
 
     def completion_begin(self, context):
         pos = self.__vim.current.window.cursor
@@ -222,9 +224,6 @@ class Deoplete(object):
             candidate['icase'] = 1
         return (complete_position, candidates)
 
-    def debug(self, expr):
-        deoplete.util.debug(self.__vim, expr)
-
     def profile_start(self, name):
         if self.__profile_flag is 0:
             return
@@ -284,6 +283,7 @@ class Deoplete(object):
                 'converters', source.converters)
 
             self.__sources[name] = source
+            self.debug('Loaded Source: %s (%s)', name, module.__file__)
         # self.debug(self.__sources)
 
     def load_filters(self):
@@ -298,6 +298,7 @@ class Deoplete(object):
                 'deoplete.filters.' + name, path).load_module()
             if hasattr(filter, 'Filter') and name not in self.__filters:
                 self.__filters[name] = filter.Filter(self.__vim)
+                self.debug('Loaded Filter: %s (%s)', name, filter.__file__)
         # self.debug(self.__filters)
 
     def is_skip(self, context, disabled_syntaxes,

--- a/rplugin/python3/deoplete/filters/base.py
+++ b/rplugin/python3/deoplete/filters/base.py
@@ -5,10 +5,10 @@
 # ============================================================================
 
 from abc import abstractmethod
-import deoplete.util
+from deoplete.logger import LoggingMixin
 
 
-class Base(object):
+class Base(LoggingMixin):
 
     def __init__(self, vim):
         self.vim = vim
@@ -18,6 +18,3 @@ class Base(object):
     @abstractmethod
     def filter(self, context):
         pass
-
-    def debug(self, expr):
-        deoplete.util.debug(self.vim, expr)

--- a/rplugin/python3/deoplete/logger.py
+++ b/rplugin/python3/deoplete/logger.py
@@ -1,0 +1,145 @@
+# ============================================================================
+# FILE: logger.py
+# AUTHOR: Tommy Allen <tommy at esdf.io>
+# License: MIT license
+# ============================================================================
+
+import sys
+import time
+import logging
+from functools import wraps
+from collections import defaultdict
+
+import pkg_resources
+
+log_format = '%(asctime)s %(levelname)-8s (%(name)s) %(message)s'
+log_message_cooldown = 0.5
+
+root = logging.getLogger('deoplete')
+root.propagate = False
+init = False
+
+
+def getLogger(name):
+    """Get a logger that is a child of the 'root' logger.
+    """
+    return root.getChild(name)
+
+
+def setup(vim, level, output_file=None):
+    """Setup logging for Deoplete
+    """
+    global init
+    if init:
+        return
+    init = True
+
+    if output_file:
+        formatter = logging.Formatter(log_format)
+        handler = logging.FileHandler(filename=output_file)
+        handler.setFormatter(formatter)
+        handler.addFilter(DeopleteLogFilter(vim))
+        root.addHandler(handler)
+
+        level = str(level).upper()
+        if level not in ('DEBUG', 'INFO', 'WARN', 'WARNING', 'ERROR',
+                         'CRITICAL', 'FATAL'):
+            level = 'DEBUG'
+        root.setLevel(getattr(logging, level))
+
+        log = getLogger('logging')
+        log.info('--- Deoplete Log Start ---')
+        log.info('%s, Python %s, neovim client %s',
+                 vim.call('deoplete#util#neovim_version'),
+                 '.'.join(map(str, sys.version_info[:3])),
+                 pkg_resources.get_distribution('neovim').version)
+        vim.call('deoplete#util#print_warning', 'Logging to %s' % output_file)
+
+
+def logmethod(func):
+    """Decorator for setting up the logger in LoggingMixin subclasses.
+
+    This does not guarantee that log messages will be generated.  It is
+    contingent on g:deoplete#enable_debug being set by the user.  If
+    `LoggingMixin.debug_enabled` is True, it will be propagated up to the root
+    'deoplete' logger.
+    """
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if not init or not self.debug_enabled:
+            return
+        if self._logger is None:
+            self._logger = getLogger(
+                getattr(self, '__logname', getattr(self, 'name', 'unknown')))
+        return func(self, *args, **kwargs)
+    return wrapper
+
+
+class LoggingMixin(object):
+    """Class that adds logging functions to a subclass.
+    """
+    debug_enabled = False
+    _logger = None
+
+    @logmethod
+    def debug(self, msg, *args, **kwargs):
+        self._logger.debug(msg, *args, **kwargs)
+
+    @logmethod
+    def info(self, msg, *args, **kwargs):
+        self._logger.info(msg, *args, **kwargs)
+
+    @logmethod
+    def warning(self, msg, *args, **kwargs):
+        self._logger.warning(msg, *args, **kwargs)
+    warn = warning
+
+    @logmethod
+    def error(self, msg, *args, **kwargs):
+        self._logger.error(msg, *args, **kwargs)
+
+    @logmethod
+    def exception(self, msg, *args, **kwargs):
+        # This will not produce a log message if there is no exception to log.
+        self._logger.exception(msg, *args, **kwargs)
+
+    @logmethod
+    def critical(self, msg, *args, **kwargs):
+        self._logger.critical(msg, *args, **kwargs)
+    fatal = critical
+
+
+class DeopleteLogFilter(logging.Filter):
+    def __init__(self, vim, name=''):
+        self.vim = vim
+        self.counter = defaultdict(int)
+        self.last_message_time = 0
+        self.last_message = None
+
+    def filter(self, record):
+        t = time.time()
+        elapsed = t - self.last_message_time
+        self.last_message_time = t
+
+        message = (record.levelno, record.name, record.msg, record.args)
+        if message == self.last_message and elapsed < log_message_cooldown:
+            # Ignore if the same message comes in too fast.
+            return False
+        self.last_message = message
+
+        if record.levelno >= logging.ERROR:
+            self.counter[record.name] += 1
+            if self.counter[record.name] <= 2:
+                # Only permit 2 errors in succession from a logging source to
+                # display errors inside of Neovim.  After this, it is no longer
+                # permitted to emit any more errors and should be addressed.
+                self.vim.call('deoplete#util#print_error', record.getMessage())
+            if record.exc_info and record.stack_info:
+                # Add a penalty for messages that generate exceptions to avoid
+                # making the log harder to read with doubled stack traces.
+                self.counter[record.name] += 1
+        elif self.counter[record.name] < 2:
+            # If below the threshold for silencing a logging source, reset its
+            # counter.
+            self.counter[record.name] = 0
+        return True

--- a/rplugin/python3/deoplete/sources/base.py
+++ b/rplugin/python3/deoplete/sources/base.py
@@ -6,10 +6,10 @@
 
 import re
 from abc import abstractmethod
-import deoplete.util
+from deoplete.logger import LoggingMixin
 
 
-class Base(object):
+class Base(LoggingMixin):
 
     def __init__(self, vim):
         self.vim = vim
@@ -35,6 +35,3 @@ class Base(object):
     @abstractmethod
     def gather_candidate(self, context):
         pass
-
-    def debug(self, expr):
-        deoplete.util.debug(self.vim, expr)


### PR DESCRIPTION
This uses Python's logging facility to log messages to a file instead of printing messages to Neovim's message history.  It produces the following output when `g:deoplete#enable_debug` is on:

```
2016-03-17 17:20:59,010 INFO     (deoplete.logging) --- Deoplete Log Start ---
2016-03-17 17:20:59,011 INFO     (deoplete.logging) NVIM 0.1.3-dev, Python 3.4.3, neovim client 0.1.4
2016-03-17 17:20:59,016 DEBUG    (deoplete.core) Loaded Source: ultisnips (/home/tallen/.vim/plugged/ultisnips/rplugin/python3/deoplete/sources/ultisnips.py)
2016-03-17 17:20:59,016 DEBUG    (deoplete.core) Loaded Source: buffer (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/sources/buffer.py)
2016-03-17 17:20:59,017 DEBUG    (deoplete.core) Loaded Source: dictionary (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/sources/dictionary.py)
2016-03-17 17:20:59,017 DEBUG    (deoplete.core) Loaded Source: file (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/sources/file.py)
2016-03-17 17:20:59,018 DEBUG    (deoplete.core) Loaded Source: member (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/sources/member.py)
2016-03-17 17:20:59,018 DEBUG    (deoplete.core) Loaded Source: omni (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/sources/omni.py)
2016-03-17 17:20:59,019 DEBUG    (deoplete.core) Loaded Source: tag (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/sources/tag.py)
2016-03-17 17:20:59,094 DEBUG    (deoplete.core) Loaded Source: deoplete_jedi (/home/tallen/dev/vim/deoplete-jedi/rplugin/python3/deoplete/sources/deoplete_jedi.py)
2016-03-17 17:20:59,098 DEBUG    (deoplete.core) Loaded Filter: converter_auto_delimiter (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/filters/converter_auto_delimiter.py)
2016-03-17 17:20:59,098 DEBUG    (deoplete.core) Loaded Filter: converter_auto_paren (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/filters/converter_auto_paren.py)
2016-03-17 17:20:59,098 DEBUG    (deoplete.core) Loaded Filter: converter_remove_overlap (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/filters/converter_remove_overlap.py)
2016-03-17 17:20:59,098 DEBUG    (deoplete.core) Loaded Filter: converter_remove_paren (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/filters/converter_remove_paren.py)
2016-03-17 17:20:59,099 DEBUG    (deoplete.core) Loaded Filter: matcher_full_fuzzy (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/filters/matcher_full_fuzzy.py)
2016-03-17 17:20:59,099 DEBUG    (deoplete.core) Loaded Filter: matcher_fuzzy (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/filters/matcher_fuzzy.py)
2016-03-17 17:20:59,099 DEBUG    (deoplete.core) Loaded Filter: matcher_head (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/filters/matcher_head.py)
2016-03-17 17:20:59,099 DEBUG    (deoplete.core) Loaded Filter: matcher_length (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/filters/matcher_length.py)
2016-03-17 17:20:59,099 DEBUG    (deoplete.core) Loaded Filter: sorter_rank (/home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/filters/sorter_rank.py)
2016-03-17 17:20:59,859 WARNING  (deoplete.jedi) caching with key: /home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/deoplete.py, lines: [48, 49]
2016-03-17 17:20:59,919 DEBUG    (deoplete.jedi) cache hit
2016-03-17 17:21:00,142 WARNING  (deoplete.jedi) caching with key: os, lines: [0, 0]
2016-03-17 17:21:05,350 WARNING  (deoplete.jedi) caching with key: os.access, lines: [0, 0]
2016-03-17 17:21:08,839 DEBUG    (deoplete.jedi) cache hit
2016-03-17 17:21:13,722 WARNING  (deoplete.jedi) caching with key: /home/tallen/dev/vim/deoplete.nvim/rplugin/python3/deoplete/deoplete.py.self, lines: [48, 49]
```

When it's disabled, it uses Python's `logging.NullHandler` so the overhead should be minimal while allowing you to keep debug messages in the source without needing to comment them out.

I set it so that if a logging source produces more than 2 error messages in succession, it is silenced and can't print to Neovim's messages until restarted.  It is still able to continue logging to the output file.  Since this plugin can potentially produce log messages on each key stroke, I also set it so that if the same message comes in within 0.5s of the last time it was logged, it is ignored.

The root logger 'deoplete' is set to not propagate, so that Neovim's logs can be inspected separately without noise from this logger.