### PR TITLE
Fix documentation of installation by vim-plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For vim-plug
     function! DoRemote(arg)
       UpdateRemotePlugins
     endfunction
-    Plug 'Shougo/deoplete.nvim' { 'do': function('DoRemote') }
+    Plug 'Shougo/deoplete.nvim', { 'do': function('DoRemote') }
 
 For dein.vim
 


### PR DESCRIPTION
There should be a command before the `{}` block: https://github.com/junegunn/vim-plug#example