### PR TITLE
fix syntax error in vim-plug example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For vim-plug
     function! DoRemote(arg)
       UpdateRemotePlugins
     endfunction
-    Plug 'Shougo/deoplete.nvim' { 'do': function('DoRemote') }
+    Plug 'Shougo/deoplete.nvim', { 'do': function('DoRemote') }
 
 For dein.vim
 


### PR DESCRIPTION
the missing comma causes a syntax error that's hard to track down. :)