### PR TITLE
Fix buffer and member source flicker

### DIFF
--- a/rplugin/python3/deoplete/sources/buffer.py
+++ b/rplugin/python3/deoplete/sources/buffer.py
@@ -29,7 +29,8 @@ class Source(Base):
             return []
 
         return [{'word': x} for x in
-                functools.reduce(operator.add, buffers)]
+                functools.reduce(operator.add, buffers)
+                if x != context['complete_str']]
 
     def on_buffer(self, context):
         if (self.vim.current.buffer.number

--- a/rplugin/python3/deoplete/sources/member.py
+++ b/rplugin/python3/deoplete/sources/member.py
@@ -45,4 +45,4 @@ class Source(Base):
         return [{'word': x} for x in
                 functools.reduce(operator.add, [
                     p.findall(x) for x in self.vim.current.buffer
-                ])]
+                ]) if x != context['complete_str']]


### PR DESCRIPTION
Excludes current completion string from results to prevent this flickering:

![flickering](https://cloud.githubusercontent.com/assets/111942/14661890/56c3be6e-067f-11e6-841d-aa6c77319f7e.gif)
