### PR TITLE
Fix 'is_skip' to give first priority to the 'disabled_syntaxes' value

### DIFF
--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -321,6 +321,9 @@ class Deoplete(logger.LoggingMixin):
 
     def is_skip(self, context, disabled_syntaxes,
                 min_pattern_length, max_pattern_length, input_pattern):
+        if ('syntax_name' in context and
+                context['syntax_name'] in disabled_syntaxes):
+            return 1
         if (input_pattern != '' and
                 re.search(input_pattern + '$', context['input'])):
             return 0
@@ -328,8 +331,7 @@ class Deoplete(logger.LoggingMixin):
                        not (min_pattern_length <=
                             len(context['complete_str']) <=
                             max_pattern_length))
-        return skip_length or ('syntax_name' in context and
-                               context['syntax_name'] in disabled_syntaxes)
+        return skip_length
 
     def position_has_changed(self, pos):
         return (pos != self.__vim.current.window.cursor or


### PR DESCRIPTION
If set `disabled_syntaxes`, but `input_pattern` takes precedence over it.
I was fixing to give first priority to the `disabled_syntaxes` value.

e.g. ( `|` is cursor )
```vim
call deoplete#custom#set('go', 'disabled_syntaxes', ['Comment'])
```

```go
package main

import (
	"fmt"
)


func main() {
	// fmt.|
	fmt.Println("test for deoplete.nvim")
}
```

Please feel free to point out.