### PR TITLE
Fix regex bug when input_pattern contains '|'

### DIFF
--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -327,7 +327,7 @@ class Deoplete(logger.LoggingMixin):
                 context['syntax_name'] in disabled_syntaxes):
             return 1
         if (input_pattern != '' and
-                re.search(input_pattern + '$', context['input'])):
+                re.search('(' + input_pattern + ')$', context['input'])):
             return 0
         skip_length = (context['event'] != 'Manual' and
                        not (min_pattern_length <=


### PR DESCRIPTION
This should close https://github.com/zchee/deoplete-clang/issues/28 .