### PR TITLE
Fix if...else conditional of initialize sources mark

### DIFF
--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -163,8 +163,8 @@ class Deoplete(logger.LoggingMixin):
                 context['candidates'] = source.on_post_filter(context)
 
             candidates = context['candidates']
-            if candidates and source.mark != '' and candidates[0].get(
-                    'menu', '').find(source.mark) != 0:
+            if candidates and (source.mark == '' or candidates[0].get(
+                    'menu', '').find(source.mark) != 0):
                 # Set default menu
                 for candidate in candidates:
                     candidate['menu'] = source.mark + ' ' + candidate.get(


### PR DESCRIPTION
I think if each source had set `self.mark`, "***Set default menu***" for loop will not need.
If want to avoid the loop, that hack was necessary until now.
https://github.com/zchee/deoplete-go/blob/master/rplugin/python3/deoplete/sources/deoplete_go.py#L141

It will work(jedi, go, clang and neosnippet), but I do not know the side effects.
If you have time, Please code review.