### PR TITLE
Fix if conditional of initialize sources mark and merge set icase

### DIFF
--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -163,12 +163,14 @@ class Deoplete(logger.LoggingMixin):
                 context['candidates'] = source.on_post_filter(context)
 
             candidates = context['candidates']
-            if candidates and source.mark != '' and candidates[0].get(
-                    'menu', '').find(source.mark) != 0:
-                # Set default menu
+            if candidates:
+                # Set default menu and icase
                 for candidate in candidates:
-                    candidate['menu'] = source.mark + ' ' + candidate.get(
-                        'menu', '')
+                    candidate['icase'] = 1
+                    if source.mark != '' and candidate.get(
+                            'menu', '').find(source.mark) != 0:
+                        candidate['menu'] = source.mark + ' ' + candidate.get(
+                            'menu', '')
 
             # self.debug(context['candidates'])
         return results
@@ -226,9 +228,6 @@ class Deoplete(logger.LoggingMixin):
         if self.__vim.vars['deoplete#max_list'] > 0:
             candidates = candidates[: self.__vim.vars['deoplete#max_list']]
 
-        # Set icase
-        for candidate in candidates:
-            candidate['icase'] = 1
         return (complete_position, candidates)
 
     def profile_start(self, name):


### PR DESCRIPTION
Fixed before pull request.

Merge set `icase` and `mark` for loop.
If want to avoid the loop, that hack was necessary until now.
https://github.com/zchee/deoplete-go/blob/master/rplugin/python3/deoplete/sources/deoplete_go.py#L141

It will work(jedi, go, clang and neosnippet), but I do not know the side effects.
If you have time, Please code review.

===

Sorry, I mistake, this branch had been pushed to the original `Shougo/deoplete.nvim` :(
I am reflecting....