### PR TITLE
Ignore empty abbr in delimiter auto converter

### DIFF
--- a/rplugin/python3/deoplete/filters/converter_auto_delimiter.py
+++ b/rplugin/python3/deoplete/filters/converter_auto_delimiter.py
@@ -17,13 +17,16 @@ class Filter(Base):
     def filter(self, context):
         delimiters = self.vim.vars['deoplete#delimiters']
         for candidate, delimiter in [
-                [x, last_find(x['abbr'], delimiters)[0]]
+                [x, last_find(x['abbr'], delimiters)]
                 for x in context['candidates']
-                if ('abbr' in x) and not last_find(x['word'], delimiters) and
+                if 'abbr' in x and x['abbr'] and
+                not last_find(x['word'], delimiters) and
                 last_find(x['abbr'], delimiters)]:
             candidate['word'] += delimiter
         return context['candidates']
 
 
 def last_find(s, needles):
-    return [x for x in needles if s.rfind(x) == (len(s) - len(x))]
+    for needle in needles:
+        if len(s) >= len(needle) and s[-len(needle):] == needle:
+            return needle


### PR DESCRIPTION
For completion sources that return a dict with empty `abbr` values, the delimiter auto converter will match all delimiters to the empty string.

The problem:

```
[x for x in needles if s.rfind(x) == (len(s) - len(x))]
```

`s.rfind(x)` will return `-1` when `s` is empty.  `len(s)` will be `0` and `len(x)` will be `1`.  This will evaluate to `-1 == -1`, which causes a match for _all_ 1 character delimiters.  So, the first delimiter will be used.

I also rewrote `last_find()` to stop at the first match instead of testing all delimiters.  Instead of using `.rfind()` which will scan the entire string, use `s[-1:]` instead to match expected region for the delimiter.  This will give a very minor performance increase.