### PR TITLE
Fix buffer config

### DIFF
--- a/rplugin/python3/deoplete/util.py
+++ b/rplugin/python3/deoplete/util.py
@@ -19,7 +19,7 @@ def get_buffer_config(context, filetype, buffer_var, user_var, default_var):
     ft = filetype if (filetype in context['vars'][user_var] or
                       filetype in context['vars'][default_var]) else '_'
     default = context['vars'][default_var].get(ft, '')
-    return context['vars'][user_var].get(filetype, default)
+    return context['vars'][user_var].get(ft, default)
 
 
 def get_simple_buffer_config(context, buffer_var, user_var):


### PR DESCRIPTION
Since https://github.com/Shougo/deoplete.nvim/commit/4d18f71eb1f64668deced1d1e16f145045897ab6, the default filetype of the user config was ignored.