### PR TITLE
Optimized path parsing in file source

### DIFF
--- a/rplugin/python3/deoplete/source/file.py
+++ b/rplugin/python3/deoplete/source/file.py
@@ -57,31 +57,18 @@ class Source(Base):
                 ] + [{'word': x} for x in files]
 
     def __longest_path_that_exists(self, context, input_str):
-        data = [input_str]
-        m = re.search(self.__isfname, input_str)
-        if m and m.group(0) != '':
-            data = re.split(self.__isfname, input_str)
-        pos = [" ".join(data[i:]) for i in range(len(data))]
-        existing_paths = list(filter(lambda x: exists(
-            dirname(self.__substitute_path(context, x))), pos))
-        if existing_paths and len(existing_paths) > 0:
-            return sorted(existing_paths)[-1]
-        return None
+        data = re.split(r'(%s+)' % self.__isfname, input_str)
+        data = [''.join(data[i:]) for i in range(len(data))]
+        existing_paths = sorted(filter(lambda x: exists(
+            dirname(self.__substitute_path(context, x))), data))
+        return existing_paths[-1] if existing_paths else None
 
     def __substitute_path(self, context, path):
-        m = re.match(r'(\.+)/', path)
+        m = re.match(r'(\.{1,2})/+', path)
         if m:
-            h = self.vim.funcs.repeat(':h', len(m.group(1)))
-            return re.sub(r'^\.+',
-                          self.vim.funcs.fnamemodify(
-                              (context['bufname']
-                               if self.__buffer_path
-                               else context['cwd']), ':p' + h),
-                          path)
-        m = re.match(r'~/', path)
-        if m and os.environ.get('HOME'):
-            return re.sub(r'^~', os.environ.get('HOME'), path)
-        m = re.match(r'\$([A-Z_]+)/', path)
-        if m and os.environ.get(m.group(1)):
-            return re.sub(r'^\$[A-Z_]+', os.environ.get(m.group(1)), path)
-        return path
+            base = context['bufname'] if self.__buffer_path else context['cwd']
+            for _ in m.group(1):
+                base = dirname(base)
+            path = os.path.abspath(os.path.join(base, path[len(m.group(0)):]))
+            return path
+        return os.path.expandvars(os.path.expanduser(path))


### PR DESCRIPTION
`__longest_path_that_exists` was discarding `[^\f]` matches even though they could be part of an actual file path.  It's still split, but all of the original text is retained when checking paths.  Otherwise files with multiple spaces, escaped characters `\ `, or other non-standard characters that do exist won't work.

`__substitute_path` was using Vim to parse the path, but Python is well equipped to handle it.  `os.path.expanduser()` will work correctly even if `$HOME` doesn't exist.  Also, the pattern was allowing paths like `.../` to move up one directory per dot.  It's changed to only allow a max of 2 dots since this may be unexpected behavior.  If this was expected, let me know and I'll restore it.