### PR TITLE
Handle completion delay in Vim instead of in Python

### DIFF
--- a/autoload/deoplete/handler.vim
+++ b/autoload/deoplete/handler.vim
@@ -24,7 +24,25 @@ function! deoplete#handler#_init() abort "{{{
   call s:on_event('')
 endfunction"}}}
 
-function! s:completion_begin(event) abort "{{{
+function! s:completion_begin_delayed(timer) abort "{{{
+  unlet! s:completion_delay
+  call s:completion_begin(s:delayed_event, 1)
+endfunction"}}}
+
+function! s:completion_begin(event, ...) abort "{{{
+  if has('timers') && !a:0 && g:deoplete#auto_complete_delay > 0
+    if exists('s:completion_delay')
+      call timer_stop(s:completion_delay)
+    endif
+
+    if a:event != 'Manual'
+      let s:delayed_event = a:event
+      let s:completion_delay = timer_start(g:deoplete#auto_complete_delay,
+            \ 's:completion_begin_delayed')
+      return
+    endif
+  endif
+
   let context = deoplete#init#_context(a:event, [])
 
   if s:is_skip(a:event, context)

--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -180,8 +180,8 @@ g:deoplete#max_menu_width
 
 					*g:deoplete#auto_complete_delay*
 g:deoplete#auto_complete_delay
-		It is the auto completion delay time after your input.
-		The unit is ms.
+		Delay the completion after input in milliseconds.
+		Requires |+timers| (Neovim 0.1.5)
 
 		Default value: 0
 

--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -37,11 +37,6 @@ class Deoplete(logger.LoggingMixin):
         self.name = 'core'
 
     def completion_begin(self, context):
-        if context['event'] != 'Manual' and context['delay'] > 0:
-            time.sleep(context['delay'] / 1000.0)
-            if self.position_has_changed(context['changedtick']):
-                return
-
         try:
             complete_position, candidates = self.gather_candidates(context)
         except Exception:


### PR DESCRIPTION
This uses a `timer_start()` in VimL to delay sending the context via `rpcnotify()` instead of using `time.sleep()` in Python.

@yrjan noticed that the `time.sleep()` was accumulating and causing long delays after typing a lot.  The other problem is that even if it was corrected to not block subsequent calls, the context would be old by the time completion happens.

Using `time.sleep()` with `500ms` delay to exaggerate the issue:

![ezgif-8705343](https://cloud.githubusercontent.com/assets/111942/16750475/0b622d36-47a0-11e6-98d7-50844f94b2d3.gif)

Using `timer_start()` also has a nice side effect.  If you set the delay to `50ms` it will resolve the flickering when pressing backspace.  Maybe it can be set by default?

With `50ms` delay:

![delay](https://cloud.githubusercontent.com/assets/111942/16750300/e94424c6-479e-11e6-85b3-e5e8990b2f85.gif)

No delay:

![no delay](https://cloud.githubusercontent.com/assets/111942/16750295/ded7ad14-479e-11e6-8101-fc63879e9c2b.gif)
