### PR TITLE
Use a timer thread to handle delayed completion

### DIFF
--- a/autoload/deoplete/handler.vim
+++ b/autoload/deoplete/handler.vim
@@ -11,8 +11,8 @@ function! deoplete#handler#_init() abort "{{{
     autocmd CompleteDone * call s:complete_done()
     autocmd InsertCharPre * call s:on_insert_char_pre()
 
-    autocmd TextChangedI * call s:completion_begin("TextChangedI")
-    autocmd InsertEnter * call s:completion_begin("InsertEnter")
+    autocmd TextChangedI * call s:completion_begin("TextChangedI", 0)
+    autocmd InsertEnter * call s:completion_begin("InsertEnter", 0)
   augroup END
 
   for event in [
@@ -24,10 +24,14 @@ function! deoplete#handler#_init() abort "{{{
   call s:on_event('')
 endfunction"}}}
 
-function! s:completion_begin(event) abort "{{{
+function! deoplete#handler#_delay_trigger() abort "{{{
+  call s:completion_begin('TextChangedI', 1)
+endfunction"}}}
+
+function! s:completion_begin(event, delayed) abort "{{{
   let context = deoplete#init#_context(a:event, [])
 
-  if s:is_skip(a:event, context)
+  if !a:delayed && s:is_skip(a:event, context)
     return
   endif
 
@@ -35,6 +39,10 @@ function! s:completion_begin(event) abort "{{{
   let g:deoplete#_context.position = context.position
 
   let g:deoplete#_context.refresh = 0
+
+  if a:delayed
+    let context.delay = 0
+  endif
 
   " Call omni completion
   for filetype in context.filetypes

--- a/rplugin/python3/deoplete/delay.py
+++ b/rplugin/python3/deoplete/delay.py
@@ -1,0 +1,24 @@
+# ============================================================================
+# FILE: delay.py
+# AUTHOR: Tommy Allen <tommy at esdf.io>
+# License: MIT license
+# ============================================================================
+
+from threading import Timer
+
+
+class DelayTimer(object):
+    """Reusable timer for delayed completions."""
+
+    def __init__(self, vim):
+        self.timer = None
+        self.vim = vim
+
+    def callback(self):
+        self.vim.async_call(self.vim.call, 'deoplete#handler#_delay_trigger')
+
+    def start(self, interval):
+        if self.timer is not None:
+            self.timer.cancel()
+        self.timer = Timer(interval, self.callback)
+        self.timer.start()

--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -7,6 +7,7 @@
 from deoplete.util import \
     error, globruntime, charpos2bytepos, \
     bytepos2charpos, get_custom, get_syn_name, get_buffer_config
+from deoplete.delay import DelayTimer
 
 import deoplete.source
 import deoplete.filter
@@ -34,13 +35,13 @@ class Deoplete(logger.LoggingMixin):
         self.__custom = []
         self.__profile_flag = None
         self.__profile_start = 0
+        self.__delay = DelayTimer(vim)
         self.name = 'core'
 
     def completion_begin(self, context):
         if context['event'] != 'Manual' and context['delay'] > 0:
-            time.sleep(context['delay'] / 1000.0)
-            if self.position_has_changed(context['changedtick']):
-                return
+            self.__delay.start(context['delay'] / 1000.0)
+            return
 
         try:
             complete_position, candidates = self.gather_candidates(context)


### PR DESCRIPTION
Originally #304 

@yrjan noticed that the `time.sleep()` was accumulating and causing long delays after typing a lot.  The other problem is that even if it was corrected to not block subsequent calls, the context would be old by the time completion happens.

Using `time.sleep()` with `500ms` delay to exaggerate the issue:

![ezgif-8705343](https://cloud.githubusercontent.com/assets/111942/16750475/0b622d36-47a0-11e6-98d7-50844f94b2d3.gif)

Using `timer_start()` also has a nice side effect.  If you set the delay to `50ms` it will resolve the flickering when pressing backspace.  Maybe it can be set by default?

With `50ms` delay:

![delay](https://cloud.githubusercontent.com/assets/111942/16750300/e94424c6-479e-11e6-85b3-e5e8990b2f85.gif)

No delay:

![no delay](https://cloud.githubusercontent.com/assets/111942/16750295/ded7ad14-479e-11e6-8101-fc63879e9c2b.gif)
