### PR TITLE
Fix file source base for new buffers

### DIFF
--- a/rplugin/python3/deoplete/source/file.py
+++ b/rplugin/python3/deoplete/source/file.py
@@ -66,7 +66,11 @@ class Source(Base):
     def __substitute_path(self, context, path):
         m = re.match(r'(\.{1,2})/+', path)
         if m:
-            base = context['bufname'] if self.__buffer_path else context['cwd']
+            if self.__buffer_path and context['bufname']:
+                base = context['bufname']
+            else:
+                base = os.path.join(context['cwd'], 'x')
+
             for _ in m.group(1):
                 base = dirname(base)
             path = os.path.abspath(os.path.join(base, path[len(m.group(0)):]))


### PR DESCRIPTION
Use `cwd` if the buffer doesn't have a filename when buffer path completion is enabled.