### PR TITLE
Add a simple health checker

### DIFF
--- a/autoload/health/deoplete.vim
+++ b/autoload/health/deoplete.vim
@@ -1,6 +1,7 @@
 "=============================================================================
 " FILE: deoplete.vim
 " AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
+"         TJ DeVries <devries.timothyj at gmail.com>
 " License: MIT license
 "=============================================================================
 
@@ -8,7 +9,8 @@ function! s:check_neovim() abort
   if has('nvim')
     call health#report_ok('has("nvim") was successful')
   else
-    call health#report_error('has("nvim") was not successful', 'Deoplete only works for neovim!')
+    call health#report_error('has("nvim") was not successful',
+          \ 'Deoplete only works for neovim!')
   endif
 endfunction
 
@@ -19,7 +21,8 @@ function! s:check_required_python_for_deoplete() abort
     call health#report_error('has("python3") was not successful', [
           \ 'Please install the python3 package for neovim.',
           \ 'A good guide can be found here: ' .
-          \ 'https://github.com/tweekmonster/nvim-python-doctor/wiki/Advanced:-Using-pyenv'
+          \ 'https://github.com/tweekmonster/nvim-python-doctor/'
+          \ . 'wiki/Advanced:-Using-pyenv'
           \ ]
           \ )
   endif

--- a/autoload/health/deoplete.vim
+++ b/autoload/health/deoplete.vim
@@ -1,0 +1,38 @@
+
+function! s:check_neovim() abort
+  if has('nvim')
+    call health#report_ok('has("nvim") was successful')
+  else
+    call health#report_error('has("nvim") was not successful', 'Deoplete only works for neovim!')
+  endif
+endfunction
+
+function! s:check_required_python_for_deoplete() abort
+  if has('python3')
+    call health#report_ok('has("python3") was successful')
+  else
+    call health#report_error('has("python3") was not successful', [
+          \ 'Please install the python3 package for neovim.',
+          \ 'A good guide can be found here: https://github.com/tweekmonster/nvim-python-doctor/wiki/Advanced:-Using-pyenv'
+          \ ]
+          \ )
+  endif
+endfunction
+
+function! s:still_have_issues() abort
+  let l:indentation = '        '
+  call health#report_info("If you're still having problems, try the following commands:\n" .
+        \ l:indentation . "$ export NVIM_PYTHON_LOG_FILE=/tmp/log\n" .
+        \ l:indentation . "$ export NVIM_PYTHON_LOG_LEVEL=DEBUG\n" .
+        \ l:indentation . "$ nvim\n" .
+        \ l:indentation . "$ cat /tmp/log_{PID}\n" .
+        \ l:indentation . ' and then create an issue on github'
+        \ )
+endfunction
+
+function! health#deoplete#check() abort
+  call health#report_start('Deoplete.nvim')
+  call s:check_neovim()
+  call s:check_required_python_for_deoplete()
+  call s:still_have_issues()
+endfunction

--- a/autoload/health/deoplete.vim
+++ b/autoload/health/deoplete.vim
@@ -1,3 +1,8 @@
+"=============================================================================
+" FILE: deoplete.vim
+" AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
+" License: MIT license
+"=============================================================================
 
 function! s:check_neovim() abort
   if has('nvim')
@@ -13,25 +18,27 @@ function! s:check_required_python_for_deoplete() abort
   else
     call health#report_error('has("python3") was not successful', [
           \ 'Please install the python3 package for neovim.',
-          \ 'A good guide can be found here: https://github.com/tweekmonster/nvim-python-doctor/wiki/Advanced:-Using-pyenv'
+          \ 'A good guide can be found here: ' .
+          \ 'https://github.com/tweekmonster/nvim-python-doctor/wiki/Advanced:-Using-pyenv'
           \ ]
           \ )
   endif
 endfunction
 
 function! s:still_have_issues() abort
-  let l:indentation = '        '
-  call health#report_info("If you're still having problems, try the following commands:\n" .
-        \ l:indentation . "$ export NVIM_PYTHON_LOG_FILE=/tmp/log\n" .
-        \ l:indentation . "$ export NVIM_PYTHON_LOG_LEVEL=DEBUG\n" .
-        \ l:indentation . "$ nvim\n" .
-        \ l:indentation . "$ cat /tmp/log_{PID}\n" .
-        \ l:indentation . ' and then create an issue on github'
+  let indentation = '        '
+  call health#report_info("If you're still having problems, ' .
+        \ 'try the following commands:\n" .
+        \ indentation . "$ export NVIM_PYTHON_LOG_FILE=/tmp/log\n" .
+        \ indentation . "$ export NVIM_PYTHON_LOG_LEVEL=DEBUG\n" .
+        \ indentation . "$ nvim\n" .
+        \ indentation . "$ cat /tmp/log_{PID}\n" .
+        \ indentation . ' and then create an issue on github'
         \ )
 endfunction
 
 function! health#deoplete#check() abort
-  call health#report_start('Deoplete.nvim')
+  call health#report_start('deoplete.nvim')
   call s:check_neovim()
   call s:check_required_python_for_deoplete()
   call s:still_have_issues()


### PR DESCRIPTION
Shougo,

I mentioned in gitter yesterday adding your own deoplete health checker. This PR just adds a very simple one for you. Feel free to just delete everything I wrote and use it as a template if you'd like, but I thought you might like a starting point.

When someone uses `:CheckHealth` with this in your plugin, the output would now look something like:

--------------------------------------------------------------------------------
--------------------------------------------------------------------------------

# Checking health
--------------------------------------------------------------------------------

## Checker health#deoplete#check says:

  - Checking: Deoplete.nvim
    - SUCCESS: has("nvim") was successful
    - SUCCESS: has("python3") was successful
    - INFO: If you're still having problems, try the following commands:

        $ export NVIM_PYTHON_LOG_FILE=/tmp/log

        $ export NVIM_PYTHON_LOG_LEVEL=DEBUG

        $ nvim

        $ cat /tmp/log_{PID}

         and then create an issue on github

--------------------------------------------------------------------------------

## Checker health#nvim#check says:

. . .

--------------------------------------------------------------------------------
--------------------------------------------------------------------------------


If you have any questions, let me know! I'd be glad to help.

Thanks for making such an awesome plugin! 