### PR TITLE
Ensure that b:changedtick is unchanged with delayed completion

### DIFF
--- a/autoload/deoplete/handler.vim
+++ b/autoload/deoplete/handler.vim
@@ -24,12 +24,6 @@ function! deoplete#handler#_init() abort "{{{
   call s:on_event('')
 endfunction"}}}
 
-function! s:completion_delayed(timer) abort "{{{
-  let timer = s:timer
-  unlet! s:timer
-  call s:completion_begin(timer.event)
-endfunction"}}}
-
 function! s:completion_check(event) abort "{{{
   let delay = get(g:deoplete#_context, 'refresh', 0) ?
         \ g:deoplete#auto_refresh_delay : g:deoplete#auto_complete_delay
@@ -39,13 +33,21 @@ function! s:completion_check(event) abort "{{{
     endif
 
     if a:event != 'Manual'
-      let s:timer = { 'event': a:event }
+      let s:timer = { 'event': a:event, 'changedtick': b:changedtick }
       let s:timer.id = timer_start(delay, 's:completion_delayed')
       return
     endif
   endif
 
   return s:completion_begin(a:event)
+endfunction"}}}
+
+function! s:completion_delayed(timer) abort "{{{
+  let timer = s:timer
+  unlet! s:timer
+  if b:changedtick == timer.changedtick
+    call s:completion_begin(timer.event)
+  endif
 endfunction"}}}
 
 function! s:completion_begin(event) abort "{{{


### PR DESCRIPTION
This adds a short-circuit for the b:changedtick check, but also uses the
tick from when the timer was started.

This is important with manual triggering of completions using e.g.
`<C-p>`, and can be seen best with long timeouts (i.e. `:let
g:deoplete#auto_complete_delay = 1000`): opening of the completion popup
triggers b:changedtick and this prevents deoplete from stomping over the
existing completions.

I have also moved s:completion_delayed down to make it easier to follow
the code.

Apart from the issue this fixes I think that having a short-circuit for
the common case of checking b:changedtick is good to have - skipping the
building of the context all the time.