### PR TITLE
Fix quotes around still_have_issues health check message.

### DIFF
--- a/autoload/health/deoplete.vim
+++ b/autoload/health/deoplete.vim
@@ -30,8 +30,8 @@ endfunction
 
 function! s:still_have_issues() abort
   let indentation = '        '
-  call health#report_info("If you're still having problems, ' .
-        \ 'try the following commands:\n" .
+  call health#report_info("If you're still having problems, " .
+        \ "try the following commands:\n" .
         \ indentation . "$ export NVIM_PYTHON_LOG_FILE=/tmp/log\n" .
         \ indentation . "$ export NVIM_PYTHON_LOG_LEVEL=DEBUG\n" .
         \ indentation . "$ nvim\n" .


### PR DESCRIPTION
The error message is currently rendering incorrectly as you can see here:

![test](https://cloud.githubusercontent.com/assets/6589866/19216418/f5f84b04-8d6f-11e6-80c1-25b4b3d412e1.png)

I *think* I did this correctly - but I didn't test it. However, I wanted to open a PR instead of just posting an issue. Please review it carefully :).