### PR TITLE
Add abort option to buffer source

### DIFF
--- a/rplugin/python3/deoplete/source/buffer.py
+++ b/rplugin/python3/deoplete/source/buffer.py
@@ -20,6 +20,7 @@ class Source(Base):
         self.mark = '[B]'
         self.__buffers = {}
         self.__max_lines = 5000
+        self.__abort_lines = 1000000
 
     def on_event(self, context):
         if ((context['bufnr'] not in self.__buffers) or
@@ -38,6 +39,9 @@ class Source(Base):
                 functools.reduce(operator.add, buffers)]
 
     def __make_cache(self, context):
+        if (len(self.vim.current.buffer) > self.__abort_lines):
+            return []
+
         try:
             if (context['bufnr'] in self.__buffers and
                     context['event'] != 'BufWritePost' and


### PR DESCRIPTION
When I edit a very large file ( ex. 2GB, 200000000line ), `__make_cache` of buffer.py consumes long time, and finally the following error occurs.

```
Error detected while processing function <SNR>96_completion_delayed[4]..<SNR>96_completion_begin:
E475: Invalid argument: Channel doesn't exist
```

I don't need buffer source at such large files, so I add the threshold of buffer length for aborting `__make_cache`.
