### PR TITLE
Improve error message when loading fails

### DIFF
--- a/autoload/deoplete/init.vim
+++ b/autoload/deoplete/init.vim
@@ -53,10 +53,11 @@ function! deoplete#init#_channel() abort "{{{
     endif
     call _deoplete()
   catch
-    call deoplete#util#print_error(
-          \ 'deoplete.nvim is not registered as Neovim remote plugins.')
-    call deoplete#util#print_error(
-          \ 'Please execute :UpdateRemotePlugins command and restart Neovim.')
+    call deoplete#util#print_error(printf(
+          \ 'deoplete failed to load: %s. '
+          \ .'Try the :UpdateRemotePlugins command and restart Neovim. '
+          \ .'See also :CheckHealth.',
+          \ v:exception))
     return 1
   endtry
 


### PR DESCRIPTION
This will result in the following message in case you have a SyntaxError
in the Python host:

> [deoplete] deoplete failed to load: Failed to load python3 host. You can try to see what happened by starting nvim with $NVIM_PYTHON_LOG_FILE set and opening the generated log file. Also, the host stderr is available in messages.. Try the :UpdateRemotePlugins command and restart Neovim.

I think it is useful to have `v:exception` in there, and to only use a
single line.  Before this, you would only see the 2nd error/line, and
there was no context about the error.