### PR TITLE
buffer: let user disable same-filetype restriction

### DIFF
--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -519,8 +519,8 @@ buffer						*deoplete-source-buffer*
 		It collects keywords from current buffer and buffers which
 		have same 'filetype', unless you specify this custom setting:
 >
-		" Collect keywords from all buffers, regardless of filetype.
-		call deoplete#custom#set('buffer', 'require_same_filetype', 0)
+		" Collect keywords from buffers of any filetype.
+		let g:deoplete#buffer_require_same_filetype = 0
 <
 		Note: It takes time to get the candidates in the first time if
 		you want to edit the large files(like Vim 22000 lines eval.c).

--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -516,8 +516,12 @@ EXAMPLES						*deoplete-examples*
 SOURCES							*deoplete-sources*
 
 buffer						*deoplete-source-buffer*
-		It collects keywords from current buffer and the buffers which
-		have same 'filetype'.
+		It collects keywords from current buffer and buffers which
+		have same 'filetype', unless you specify this custom setting:
+>
+		" Collect keywords from all buffers, regardless of filetype.
+		call deoplete#custom#set('buffer', 'require_same_filetype', 0)
+<
 		Note: It takes time to get the candidates in the first time if
 		you want to edit the large files(like Vim 22000 lines eval.c).
 

--- a/rplugin/python3/deoplete/source/buffer.py
+++ b/rplugin/python3/deoplete/source/buffer.py
@@ -29,8 +29,12 @@ class Source(Base):
     def gather_candidates(self, context):
         self.__make_cache(context)
 
-        buffers = [x['candidates'] for x in self.__buffers.values()
-                   if x['filetype'] in context['filetypes']]
+        buffer_values = self.__buffers.values()
+        if context['vars'].get('require_same_filetype', True):
+          buffer_values = [x for x in buffer_values
+                           if x['filetype'] in context['filetypes']]
+
+        buffers = [x['candidates'] for x in buffer_values]
         if not buffers:
             return []
 


### PR DESCRIPTION
This patch allows the user to disable the buffer source's same-filetype
restriction, which limits keyword collection to same-filetype buffers by
default, by exposing a new `require_same_filetype` custom setting:

    " Collect keywords from all buffers, regardless of filetype.
    call deoplete#custom#set('buffer', 'require_same_filetype', 0)

Without this patch, to complete a word from a different filetype buffer,
the user needs to switch away from Deoplete to Vim's native completion:

1. Wait for Deoplete to present its completion menu
2. Press `<C-E>` to abort Deoplete's completion menu
3. Press `<C-N>` to activate Vim's native completion