### PR TITLE
fix AttributeError

### DIFF
--- a/rplugin/python3/deoplete/source/omni.py
+++ b/rplugin/python3/deoplete/source/omni.py
@@ -56,7 +56,7 @@ class Source(Base):
                     # In the blacklist
                     error_vim(self.vim,
                               'omni source does not support omnifunction: ' +
-                              self.__omnifunc)
+                              omnifunc)
                     error_vim(self.vim,
                               'You must use g:deoplete#omni#input_patterns' +
                               ' instead.')


### PR DESCRIPTION
Error has occured when `omnifunction` is unsupported.

```
[deoplete] Traceback (most recent call last):
[deoplete]   File "/Users/pocari/.cache/dein/repos/github.com/Shougo/deoplete.nvim/rplugin/python3/deoplete/deoplete.py", line 73, in gather_results
[deoplete]     charpos = source.get_complete_position(ctx)
[deoplete]   File "/Users/pocari/.cache/dein/repos/github.com/Shougo/deoplete.nvim/rplugin/python3/deoplete/source/omni.py", line 59, in get_complete_position
[deoplete]     self.__omnifunc)
[deoplete] AttributeError: 'Source' object has no attribute '_Source__omnifunc'
[deoplete] Could not get completions from: omni.  Use :messages for error details.
```

I fix it.
