### PR TITLE
Make comparison operators user-setting insensitive

### DIFF
--- a/autoload/deoplete/handler.vim
+++ b/autoload/deoplete/handler.vim
@@ -30,7 +30,7 @@ function! s:completion_check(event) abort "{{{
       call timer_stop(s:timer.id)
     endif
 
-    if a:event != 'Manual'
+    if a:event !=? 'Manual'
       let s:timer = { 'event': a:event, 'changedtick': b:changedtick }
       let s:timer.id = timer_start(delay, 's:completion_delayed')
       return
@@ -66,7 +66,7 @@ function! s:completion_begin(event) abort "{{{
           \ 'b:deoplete_omni_patterns',
           \ 'g:deoplete#omni_patterns',
           \ 'g:deoplete#_omni_patterns'))
-      if pattern != '' && &l:omnifunc != ''
+      if pattern !=# '' && &l:omnifunc !=# ''
             \ && context.input =~# '\%('.pattern.'\)$'
         call deoplete#mapping#_set_completeopt()
         call feedkeys("\<C-x>\<C-o>", 'n')
@@ -92,7 +92,7 @@ function! s:is_skip(event, context) abort "{{{
   if &paste
         \ || mode() !=# 'i'
         \ || (a:event !=# 'Manual' && disable_auto_complete)
-        \ || (&l:completefunc != '' && &l:buftype =~# 'nofile')
+        \ || (&l:completefunc !=# '' && &l:buftype =~# 'nofile')
         \ || (a:event ==# 'InsertEnter'
         \     && has_key(g:deoplete#_context, 'position'))
     return 1
@@ -103,7 +103,7 @@ function! s:is_skip(event, context) abort "{{{
     let word = get(v:completed_item, 'word', '')
     let delimiters = filter(copy(g:deoplete#delimiters),
         \         'strridx(word, v:val) == (len(word) - len(v:val))')
-    if word == '' || empty(delimiters)
+    if word ==# '' || empty(delimiters)
       return 1
     endif
   endif
@@ -138,7 +138,7 @@ function! s:on_insert_leave() abort "{{{
 endfunction"}}}
 
 function! s:complete_done() abort "{{{
-  if get(v:completed_item, 'word', '') != ''
+  if get(v:completed_item, 'word', '') !=# ''
     let word = v:completed_item.word
     if !has_key(g:deoplete#_rank, word)
       let g:deoplete#_rank[word] = 1

--- a/autoload/deoplete/init.vim
+++ b/autoload/deoplete/init.vim
@@ -158,10 +158,10 @@ endfunction"}}}
 function! deoplete#init#_context(event, sources) abort "{{{
   let filetype = (exists('*context_filetype#get_filetype') ?
         \   context_filetype#get_filetype() :
-        \   (&filetype == '' ? 'nothing' : &filetype))
+        \   (&filetype ==# '' ? 'nothing' : &filetype))
   let filetypes = exists('*context_filetype#get_filetypes') ?
         \   context_filetype#get_filetypes() :
-        \   &filetype == '' ? ['nothing'] :
+        \   &filetype ==# '' ? ['nothing'] :
         \                     deoplete#util#uniq([&filetype]
         \                          + split(&filetype, '\.'))
 

--- a/autoload/deoplete/util.vim
+++ b/autoload/deoplete/util.vim
@@ -66,7 +66,7 @@ function! deoplete#util#get_input(event) abort "{{{
         \         '^.*\%' . (mode ==# 'i' ? col('.') : col('.') - 1)
         \         . 'c' . (mode ==# 'i' ? '' : '.'))
 
-  if input =~ '^.\{-}\ze\S\+$'
+  if input =~# '^.\{-}\ze\S\+$'
     let complete_str = matchstr(input, '\S\+$')
     let input = matchstr(input, '^.\{-}\ze\S\+$')
   else
@@ -96,12 +96,12 @@ function! s:vimoption2python(option) abort "{{{
   let has_dash = 0
   let patterns = []
   for pattern in split(a:option, ',')
-    if pattern == ''
+    if pattern ==# ''
       " ,
       call add(patterns, ',')
-    elseif pattern == '-'
+    elseif pattern ==# '-'
       let has_dash = 1
-    elseif pattern =~ '\d\+'
+    elseif pattern =~# '\d\+'
       call add(patterns, substitute(pattern, '\d\+',
             \ '\=nr2char(submatch(0))', 'g'))
     else


### PR DESCRIPTION
Changed all operators to strict variants, so user's `ignorecase`
settings don't have to be taken into account.