### PR TITLE
Do not call deoplete#init#_enable twice with

### DIFF
--- a/autoload/deoplete/init.vim
+++ b/autoload/deoplete/init.vim
@@ -30,13 +30,6 @@ function! deoplete#init#_initialize() abort "{{{
 
   call deoplete#mapping#_init()
   call deoplete#init#_variables()
-
-  let s:is_enabled = g:deoplete#enable_at_startup
-  if s:is_enabled
-    call deoplete#init#_enable()
-  else
-    call deoplete#init#_disable()
-  endif
 endfunction"}}}
 function! deoplete#init#_channel() abort "{{{
   if !has('nvim') || !has('python3')


### PR DESCRIPTION
With g:deoplete#enable_at_startup, `deoplete#init#_enable` gets called
twice, which results in the sources being initialized twice:

```
deoplete#enable
deoplete#initialize
deoplete#init#_initialize
deoplete#init#_enable
deoplete#handler#_init
s:on_event ''
deoplete#init#_enable
deoplete#handler#_init
s:on_event ''
```