### PR TITLE
Ignore sources that have None for the filetypes attribute

### DIFF
--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -189,7 +189,7 @@ class Deoplete(logger.LoggingMixin):
                                   {}))
 
         for source_name, source in sources:
-            if (source_name in ignore_sources):
+            if source.filetypes is None or source_name in ignore_sources:
                 continue
             if context['sources'] and source_name not in context['sources']:
                 continue


### PR DESCRIPTION
Ignore any source that sets `filetypes` to `None`.  If it's `None` the source should be considered broken or not correctly configured.  Sources that work in all files shouldn't set `filetypes` since it's the default behavior.

Related: https://github.com/carlitux/deoplete-ternjs/pull/37