### PR TITLE
"Around" source

### DIFF
--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -553,7 +553,6 @@ tag							*deoplete-source-tag*
 
 file							*deoplete-source-file*
 		This source collects keywords from local files.
-		omni
 
 omni							*deoplete-source-omni*
 		This source collects keywords from 'omnifunc'.

--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -553,6 +553,7 @@ tag							*deoplete-source-tag*
 
 file							*deoplete-source-file*
 		This source collects keywords from local files.
+		omni
 
 omni							*deoplete-source-omni*
 		This source collects keywords from 'omnifunc'.
@@ -561,6 +562,19 @@ omni							*deoplete-source-omni*
 dictionary					*deoplete-source-dictionary*
 		This source collects |g:deoplete#keyword_patterns| keywords
 		from 'dictionary'.
+
+around						    *deoplete-source-around*
+		This source collects candidates around the cursor, so inside
+		current buffer only. Plus, it searches keywords in |:changes|
+		command output. Therefore, this source is about to provide the
+		words that are in sight or the ones you've just typed somewhere
+		else.
+
+		Legend: You can see where the words came from. Next to the
+		source mark [~] these suffixes are used:
+		    A - above the cursor
+		    B - below the cursor
+		    C - in changes
 
 ==============================================================================
 FILTERS							*deoplete-filters*

--- a/rplugin/python3/deoplete/source/around.py
+++ b/rplugin/python3/deoplete/source/around.py
@@ -20,8 +20,8 @@ class Source(Base):
         # 20 lines above
         lnum = context['position'][1]
         words = parse_buffer_pattern(
-                        reversed(self.vim.call('getline', 
-                                               max([1, lnum - 20]), 
+                        reversed(self.vim.call('getline',
+                                               max([1, lnum - 20]),
                                                lnum)),
                         context['keyword_patterns'],
                         context['complete_str'])

--- a/rplugin/python3/deoplete/source/around.py
+++ b/rplugin/python3/deoplete/source/around.py
@@ -1,0 +1,55 @@
+import re
+from .base import Base
+
+from deoplete.logger import getLogger
+from deoplete.util import parse_buffer_pattern
+
+logger = getLogger('around')
+
+
+class Source(Base):
+    def __init__(self, vim):
+        super().__init__(vim)
+        self.name = 'around'
+        self.mark = '[~]'
+        self.rank = 800
+
+    def gather_candidates(self, context):
+        candidates = list()
+
+        # 20 lines above
+        lnum = context['position'][1]
+        words = parse_buffer_pattern(
+                        reversed(self.vim.call('getline', max([1, lnum - 20]), lnum)),
+                        context['keyword_patterns'],
+                        context['complete_str'])
+        candidates.extend([{'word': x, 'menu': 'A'} for x in words])
+
+        # grab ':changes' command output
+        self.vim.command('exec "redir => g:deoplete_recent_changes"')
+        self.vim.command('silent! changes')
+        self.vim.command('redir END')
+
+        p = re.compile('[\s\d]+')
+        changes = self.vim.eval('g:deoplete_recent_changes').split('\n')
+        lines = set()
+        for change in changes:
+            m = p.search(change)
+            if m:
+                line = change[m.span()[1]:]
+                if line and line != '-invalid-':
+                    lines.add(line)
+
+        words = parse_buffer_pattern(lines,
+                                     context['keyword_patterns'],
+                                     context['complete_str'])
+        candidates.extend([{'word': x, 'menu': 'C'} for x in words])
+
+        # 20 lines below
+        words = parse_buffer_pattern(
+                        self.vim.call('getline', lnum, lnum + 20),
+                        context['keyword_patterns'],
+                        context['complete_str'])
+        candidates.extend([{'word': x, 'menu': 'B'} for x in words])
+
+        return candidates

--- a/rplugin/python3/deoplete/source/around.py
+++ b/rplugin/python3/deoplete/source/around.py
@@ -6,6 +6,9 @@ from deoplete.util import parse_buffer_pattern
 
 logger = getLogger('around')
 
+ABOVE_LINES = 20
+BELOW_LINES = 20
+
 
 class Source(Base):
     def __init__(self, vim):
@@ -21,19 +24,15 @@ class Source(Base):
         lnum = context['position'][1]
         words = parse_buffer_pattern(
                         reversed(self.vim.call('getline',
-                                               max([1, lnum - 20]),
+                                               max([1, lnum - ABOVE_LINES]),
                                                lnum)),
                         context['keyword_patterns'],
                         context['complete_str'])
         candidates.extend([{'word': x, 'menu': 'A'} for x in words])
 
         # grab ':changes' command output
-        self.vim.command('exec "redir => g:deoplete_recent_changes"')
-        self.vim.command('silent! changes')
-        self.vim.command('redir END')
-
-        p = re.compile('[\s\d]+')
-        changes = self.vim.eval('g:deoplete_recent_changes').split('\n')
+        p = re.compile(r'[\s\d]+')
+        changes = self.vim.call('execute', 'changes').split('\n')
         lines = set()
         for change in changes:
             m = p.search(change)
@@ -49,7 +48,7 @@ class Source(Base):
 
         # 20 lines below
         words = parse_buffer_pattern(
-                        self.vim.call('getline', lnum, lnum + 20),
+                        self.vim.call('getline', lnum, lnum + BELOW_LINES),
                         context['keyword_patterns'],
                         context['complete_str'])
         candidates.extend([{'word': x, 'menu': 'B'} for x in words])

--- a/rplugin/python3/deoplete/source/around.py
+++ b/rplugin/python3/deoplete/source/around.py
@@ -20,7 +20,9 @@ class Source(Base):
         # 20 lines above
         lnum = context['position'][1]
         words = parse_buffer_pattern(
-                        reversed(self.vim.call('getline', max([1, lnum - 20]), lnum)),
+                        reversed(self.vim.call('getline', 
+                                               max([1, lnum - 20]), 
+                                               lnum)),
                         context['keyword_patterns'],
                         context['complete_str'])
         candidates.extend([{'word': x, 'menu': 'A'} for x in words])

--- a/rplugin/python3/deoplete/util.py
+++ b/rplugin/python3/deoplete/util.py
@@ -229,7 +229,7 @@ def expand(path):
 def getlines(vim, start=1, end='$'):
     if end == '$':
         end = len(vim.current.buffer)
-    max = 5000
+    max = min([end - start, 5000])
     lines = []
     current = start
     while current <= end:


### PR DESCRIPTION
I really hate the situation when I see a word just above/below the cursor, but this word isn't in the completion list or somewhere in the end... Same with words I've just typed, e.g. variable/property name somewhere in the beginning of method/class. I think such words must go first in the list. This is what this source about, it gathers words in 20 lines above/below and in the `:changes` output. Hit ratio ~ 80% :)

Also, I used this suffixes (menu): A - above, B - below, C - change
![around](https://i.gyazo.com/6ae3feb50d549afbd64efa2207a7f2d4.png)