### PR TITLE
Add and handle SourceInitError

### DIFF
--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -15,6 +15,7 @@ import deoplete.filter  # noqa
 import deoplete.source  # noqa
 
 from deoplete import logger
+from deoplete.exceptions import SourceInitError
 from deoplete.util import (bytepos2charpos, charpos2bytepos, error, error_tb,
                            find_rplugins, get_buffer_config, get_custom,
                            get_syn_names, import_plugin)
@@ -205,9 +206,14 @@ class Deoplete(logger.LoggingMixin):
                 try:
                     source.on_init(context)
                 except Exception as exc:
-                    error_tb(self.__vim,
-                             'Error when loading source {}. '
-                             'Ignoring.'.format(source_name, exc))
+                    if isinstance(exc, SourceInitError):
+                        error(self.__vim,
+                              'Error when loading source {}: {}. '
+                              'Ignoring.'.format(source_name, exc))
+                    else:
+                        error_tb(self.__vim,
+                                 'Error when loading source {}: {}. '
+                                 'Ignoring.'.format(source_name, exc))
                     self.__ignored_sources.add(source.path)
                     self.__sources.pop(source_name)
                     continue

--- a/rplugin/python3/deoplete/exceptions.py
+++ b/rplugin/python3/deoplete/exceptions.py
@@ -1,0 +1,6 @@
+class SourceInitError(Exception):
+    """Error during source initialization.
+
+    This can be used to have a clearer message, where not traceback gets
+    displayed.
+    """


### PR DESCRIPTION
This is meant to be by sources (e.g. deoplete-jedi) in case of clear
errors.

This also adds the formatting of `exc` to the fallback's / previously
used `error_tb`.