### PR TITLE
Support subdirectories for source and filter

### DIFF
--- a/rplugin/python3/deoplete/util.py
+++ b/rplugin/python3/deoplete/util.py
@@ -71,6 +71,7 @@ def find_rplugins(context, source):
         os.path.join('rplugin/python3/deoplete', source, 'base.py'),
         os.path.join('rplugin/python3/deoplete', source, '*.py'),
         os.path.join('rplugin/python3/deoplete', source + 's', '*.py'),
+        os.path.join('rplugin/python3/deoplete', source, '*', '*.py'),
     )
 
     for src in sources:


### PR DESCRIPTION
vim allows subdirectories under `after`, e.g. `after/syntax/c/{one,two}.vim`; this PR is analogy of that.
Of course we can separate files like `rplugin/python3/deoplete/source/c_{one,two}.py`, but it is convenient if subdirectories are available.