### PR TITLE
matcher_length should include same size matches

### DIFF
--- a/rplugin/python3/deoplete/filter/matcher_length.py
+++ b/rplugin/python3/deoplete/filter/matcher_length.py
@@ -18,4 +18,4 @@ class Filter(Base):
     def filter(self, context):
         input_len = len(context['complete_str'])
         return [x for x in context['candidates']
-                if len(x['word']) > input_len]
+                if len(x['word']) >= input_len]


### PR DESCRIPTION
`matcher_length` was filtering out candidates that were the same size as
the completion string.

For example, the string "defr" wasn't returning the exact match while "def"
would return "defr" as a match.