### PR TITLE
Don't use previous results if empty

### DIFF
--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -399,11 +399,12 @@ class Deoplete(logger.LoggingMixin):
                                                  attr, source_attr))
 
     def use_previous_result(self, context, result):
-        return (context['position'][1] == result['prev_linenr'] and
-                re.sub(r'\w*$', '', context['input']) ==
-                re.sub(r'\w*$', '', result['prev_input']) and
-                (not result['source'].is_volatile or
-                 context['input'].find(result['prev_input']) == 0))
+        return (result.get('candidates') and
+                (context['position'][1] == result['prev_linenr'] and
+                 re.sub(r'\w*$', '', context['input']) ==
+                 re.sub(r'\w*$', '', result['prev_input']) and
+                 (not result['source'].is_volatile or
+                  context['input'].find(result['prev_input']) == 0)))
 
     def is_skip(self, context, disabled_syntaxes,
                 min_pattern_length, max_pattern_length, input_pattern):


### PR DESCRIPTION
`use_previous_result()` should only return `True` if there are actually previous candidates to use.