### PR TITLE
doc: Suppress pclose output to fix command-line window

### DIFF
--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -1322,7 +1322,7 @@ And you must set |g:context_filetype#same_filetypes| variable.
 Q: I want to close the preview window after completion is done.
 
 A: >
-	autocmd CompleteDone * pclose!
+	autocmd CompleteDone * silent! pclose!
 
 Note: It conflicts with iabbr.
 https://github.com/Shougo/deoplete.nvim/issues/234


### PR DESCRIPTION
`pclose` seems to cause an error when editing a command line window (the
window you get when pressing CTRL-F while editing the "`:`" command line):

> ```
> E11: Invalid in command-line window; <CR> executes, CTRL-C quits
> ```

This works around that problem by suppressing all error messages caused
by `pclose`.