### PR TITLE
Fix: manual_complete trapped in state check

### DIFF
--- a/autoload/deoplete.vim
+++ b/autoload/deoplete.vim
@@ -27,7 +27,7 @@ function! deoplete#enable_logging(level, logfile) abort
 endfunction
 
 function! deoplete#manual_complete(...) abort
-  if deoplete#initialize()
+  if !deoplete#init#_is_enabled()
     return
   endif
 


### PR DESCRIPTION
`deoplete#initialize()` will always return 1 after deoplete is enabled, so `manual_complete` will always fall into the if clause.