### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can enable Python3 interface with pip:
 
 ## Sources
 
-deoplete will display completions via omnifunc by default.
+deoplete will display completions via `complete()` by default.
 
 Here are some [completion sources](https://github.com/Shougo/deoplete.nvim/wiki/Completion-Sources) specifically made for deoplete.nvim.
 


### PR DESCRIPTION
I may be interpreting the doc incorrectly, but, it looks like the completion method defaults to [`'complete'`](https://github.com/Shougo/deoplete.nvim/blob/1c33e9a3b118208d4c48bf3ef0a1ad77e16bc0a1/autoload/deoplete/init.vim#L111)