### PR TITLE
Gracefully handle omnifunc returning -1 in the event of an error

### DIFF
--- a/rplugin/python3/deoplete/source/omni.py
+++ b/rplugin/python3/deoplete/source/omni.py
@@ -81,9 +81,9 @@ class Source(Base):
     def gather_candidates(self, context):
         try:
             candidates = self.vim.call(self.__omnifunc, 0, '')
-            if candidates is dict:
+            if isinstance(candidates, dict):
                 candidates = candidates['words']
-            elif candidates is int:
+            elif isinstance(candidates, int):
                 candidates = []
         except Exception as e:
             self.print_error('Error occurred calling omnifunction: ' +


### PR DESCRIPTION
I'm not a python expert, but this looks to be the correct way to do this. I really just need the `int` case to work.

I have an omnifunc which returns -1 if the variable name doesn't exist and it falls through, without defaulting to an empty array as it should. Then deoplete throws nasty stacktrace.