### PR TITLE
Initialize logging in Deoplete.__init__

### DIFF
--- a/autoload/deoplete.vim
+++ b/autoload/deoplete.vim
@@ -27,6 +27,7 @@ endfunction
 
 function! deoplete#enable_logging(level, logfile) abort
   let g:deoplete#_logging = {'level': a:level, 'logfile': a:logfile}
+  call deoplete#util#rpcnotify('deoplete_enable_logging', {})
 endfunction
 
 function! deoplete#manual_complete(...) abort

--- a/autoload/deoplete/util.vim
+++ b/autoload/deoplete/util.vim
@@ -217,13 +217,6 @@ function! deoplete#util#rpcnotify(event, context) abort
   if deoplete#init#_check_channel()
     return ''
   endif
-
-  if !exists('s:logged') && !empty(g:deoplete#_logging)
-    call s:notify('deoplete_enable_logging',
-          \ deoplete#init#_context(a:event, []))
-    let s:logged = 1
-  endif
-
   call s:notify(a:event, a:context)
   return ''
 endfunction

--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -37,6 +37,12 @@ class Deoplete(logger.LoggingMixin):
         self._loaded_paths = set()
         self._prev_results = {}
 
+        # Enable logging before "Init" for more information, and e.g.
+        # deoplete-jedi picks up the log filename from deoplete's handler in
+        # its on_init.
+        if self._vim.vars['deoplete#_logging']:
+            self.enable_logging({})
+
         # on_init() call
         context = self._vim.call('deoplete#init#_context', 'Init', [])
         context['rpc'] = 'deoplete_on_event'


### PR DESCRIPTION
With something like the following you would not get logging from
deoplete-jedi's server, since sources are initialized before logging
gets setup:

    call deoplete#enable()
    call deoplete#enable_logging('DEBUG', '/tmp/deoplete.log')
    call deoplete#custom#source('jedi', 'is_debug_enabled', 1)
    let g:deoplete#sources#jedi#debug_server = 1

Initializing of sources happens for the "Init" event, whereas logging
was only configured with the first RPC afterwards.