### PR TITLE
logger: add process/PID to log_format

### DIFF
--- a/rplugin/python3/deoplete/logger.py
+++ b/rplugin/python3/deoplete/logger.py
@@ -10,7 +10,7 @@ import logging
 from functools import wraps
 from collections import defaultdict
 
-log_format = '%(asctime)s %(levelname)-8s (%(name)s) %(message)s'
+log_format = '%(asctime)s %(levelname)-8s [%(process)d] (%(name)s) %(message)s'
 log_message_cooldown = 0.5
 
 root = logging.getLogger('deoplete')


### PR DESCRIPTION
This is useful to have given that there are child processes now by
default, and also when logging to the same file from multiple sources
(Neovim instances).