### PR TITLE
Refactor Child.main to handle EOF

### DIFF
--- a/rplugin/python3/deoplete/dp_main.py
+++ b/rplugin/python3/deoplete/dp_main.py
@@ -30,16 +30,13 @@ def attach_vim(serveraddr):
 
 def main(serveraddr):
     vim = attach_vim(serveraddr)
+    from deoplete.child import Child
     from deoplete.util import error_tb
-    child = None
     try:
-        from deoplete.child import Child
         child = Child(vim)
-        while 1:
-            child.main()
+        child.main()
     except Exception:
         error_tb(vim, 'Error in child')
-    return
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I've seen child processes being left over after quitting Neovim, looping
in `read()`.
This appears to fix it.

Maybe this is what https://github.com/Shougo/deoplete.nvim/pull/625
tried to address also?!