### PR TITLE
deoplete#util#print_error: handle optional name

### DIFF
--- a/autoload/deoplete/util.vim
+++ b/autoload/deoplete/util.vim
@@ -36,9 +36,10 @@ endfunction
 function! deoplete#util#get_simple_buffer_config(buffer_var, user_var) abort
   return exists(a:buffer_var) ? {a:buffer_var} : {a:user_var}
 endfunction
-function! deoplete#util#print_error(string) abort
-  echohl Error | echomsg '[deoplete] '
-        \ . deoplete#util#string(a:string) | echohl None
+function! deoplete#util#print_error(string, ...) abort
+  let name = a:0 ? a:1 : 'deoplete'
+  echohl Error | echomsg printf('[%s] %s', name,
+        \ deoplete#util#string(a:string)) | echohl None
 endfunction
 function! deoplete#util#print_warning(string) abort
   echohl WarningMsg | echomsg '[deoplete] '

--- a/rplugin/python3/deoplete/logger.py
+++ b/rplugin/python3/deoplete/logger.py
@@ -136,7 +136,8 @@ class DeopleteLogFilter(logging.Filter):
                 # Only permit 2 errors in succession from a logging source to
                 # display errors inside of Neovim.  After this, it is no longer
                 # permitted to emit any more errors and should be addressed.
-                self.vim.call('deoplete#util#print_error', record.getMessage())
+                self.vim.call('deoplete#util#print_error', record.getMessage(),
+                              record.name)
             if record.exc_info and record.stack_info:
                 # Add a penalty for messages that generate exceptions to avoid
                 # making the log harder to read with doubled stack traces.


### PR DESCRIPTION
This is used from the Python logger to pass through the logger's name,
which is useful when logging from sources (e.g. deoplete-jedi).