### PR TITLE
logger.setup: only display "Logging to" msg once in Vim

### DIFF
--- a/rplugin/python3/deoplete/logger.py
+++ b/rplugin/python3/deoplete/logger.py
@@ -58,7 +58,11 @@ def setup(vim, level, output_file=None):
                  vim.call('deoplete#util#neovim_version'),
                  '.'.join(map(str, sys.version_info[:3])),
                  neovim_version)
-        vim.call('deoplete#util#print_debug', 'Logging to %s' % output_file)
+
+        if not vim.vars.get('deoplete#_logging_notified'):
+            vim.vars['deoplete#_logging_notified'] = 1
+            vim.call('deoplete#util#print_debug', 'Logging to %s' % (
+                output_file))
 
 
 def logmethod(func):


### PR DESCRIPTION
Something to keep in mind (i.e. reset) when disabling logging gets done (https://github.com/Shougo/deoplete.nvim/issues/615).