### PR TITLE
buffer source: skip cache with BufNew

### DIFF
--- a/rplugin/python3/deoplete/source/buffer.py
+++ b/rplugin/python3/deoplete/source/buffer.py
@@ -21,9 +21,10 @@ class Source(Base):
         self._max_lines = 5000
 
     def on_event(self, context):
+        event = context['event']
         bufnr = context['bufnr']
-        if (bufnr not in self._buffers or
-                context['event'] == 'BufWritePost'):
+        if (event == 'BufWritePost' or (
+                event != 'BufNew' and bufnr not in self._buffers)):
             self._make_cache(context, bufnr)
 
     def gather_candidates(self, context):


### PR DESCRIPTION
_make_cache acts on the current buffer, which usually is not the new
buffer with BufNew, and the buffer is supposed to be empty anyway.