### PR TITLE
reverse order of expands in deoplete.util.expand()

### DIFF
--- a/rplugin/python3/deoplete/util.py
+++ b/rplugin/python3/deoplete/util.py
@@ -236,7 +236,7 @@ def charwidth(c):
 
 
 def expand(path):
-    return os.path.expandvars(os.path.expanduser(path))
+    return os.path.expanduser(os.path.expandvars(path))
 
 
 def getlines(vim, start=1, end='$'):


### PR DESCRIPTION
With the previous order of expand calls, it's possible to have an unexpanded `~`:

```
>>> os.environ.get('FOO')
'~/src/vim'
>>> path.expandvars(path.expanduser('$FOO'))
'~/src/vim'
>>> path.expanduser(path.expandvars('$FOO'))
'/Users/zandr/src/vim'
```