### PR TITLE
Fix index error when searching tags

### DIFF
--- a/rplugin/python3/deoplete/source/tag.py
+++ b/rplugin/python3/deoplete/source/tag.py
@@ -23,6 +23,8 @@ class Source(Base):
 
     def gather_candidates(self, context):
         candidates = []
+        if len(context['complete_str']) < 2:
+            return candidates
 
         case = context['smartcase'] or context['camelcase']
         ignorecase = context['ignorecase']


### PR DESCRIPTION
I believe that [this commit](https://github.com/Shougo/deoplete.nvim/commit/ae5ea6a6d7b0e76035e9fd271fb9b672499dda32) was causing the following error message:
```
E382: Cannot write, 'buftype' option is set
[deoplete] Traceback (most recent call last):
  File "/Users/mikebowman/.vim/plugged/deoplete.nvim/rplugin/python3/deoplete/child.py", line 236, in _gather_results
    ctx['candidates'] = source.gather_candidates(ctx)
  File "/Users/mikebowman/.vim/plugged/deoplete.nvim/rplugin/python3/deoplete/source/tag.py", line 35, in gather_candidates
    if len(context['complete_str']) >= 1 else '')
IndexError: string index out of range
Errors from: tag.  Use :messages / see above for error details.
```

I added a check on the length of the context object to prevent IndexErrors. This seems to resolve the issue on my fork.