### PR TITLE
deoplete#is_enabled: do not initialize

### DIFF
--- a/autoload/deoplete.vim
+++ b/autoload/deoplete.vim
@@ -8,7 +8,6 @@ function! deoplete#initialize() abort
   return deoplete#init#_initialize()
 endfunction
 function! deoplete#is_enabled() abort
-  call deoplete#initialize()
   return deoplete#init#_is_handler_enabled()
 endfunction
 function! deoplete#enable() abort


### PR DESCRIPTION
Calling `deoplete#is_enabled()` should not trigger initialization, but
only return the current status of deoplete being enabled.