### PR TITLE
Add instructions for tab completion to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ you should read `:help provider-python` and the Wiki.
 let g:deoplete#enable_at_startup = 1
 ```
 
+### Tab completion
+
+```vim
+" Deoplete tab-complete
+inoremap <expr><tab> pumvisible() ? "\<c-n>" : "\<tab>"
+```
+
 ## Screenshots
 
 Deoplete for JavaScript


### PR DESCRIPTION
I had to dig around to find the best way to do this. I suspect this might be commonly desired from users and therefore would be useful in the README.