### PR TITLE
context: drop "runtimepath"

### DIFF
--- a/autoload/deoplete/init.vim
+++ b/autoload/deoplete/init.vim
@@ -243,7 +243,6 @@ function! deoplete#init#_context(event, sources) abort
         \ 'max_abbr_width': max_width,
         \ 'max_kind_width': max_width,
         \ 'max_menu_width': max_width,
-        \ 'runtimepath': &runtimepath,
         \ 'bufnr': bufnr,
         \ 'bufname': bufname,
         \ 'bufpath': bufpath,

--- a/rplugin/python3/deoplete/util.py
+++ b/rplugin/python3/deoplete/util.py
@@ -35,27 +35,6 @@ def globruntime(runtimepath, path):
     return ret
 
 
-def find_rplugins(context, source):
-    """Search for base.py or *.py
-
-    Searches $VIMRUNTIME/*/rplugin/python3/deoplete/$source[s]/
-    """
-    rtp = context.get('runtimepath', '').split(',')
-    if not rtp:
-        return
-
-    sources = (
-        os.path.join('rplugin/python3/deoplete', source, 'base.py'),
-        os.path.join('rplugin/python3/deoplete', source, '*.py'),
-        os.path.join('rplugin/python3/deoplete', source + 's', '*.py'),
-        os.path.join('rplugin/python3/deoplete', source, '*', '*.py'),
-    )
-
-    for src in sources:
-        for path in rtp:
-            yield from glob.iglob(os.path.join(path, src))
-
-
 def import_plugin(path, source, classname):
     """Import Deoplete plugin source class.
 


### PR DESCRIPTION
It is a lot of overhead (especially with many plugins installed).

`vim.options['runtimepath']` can be used instead if necessary.

Adjusts cpsm matcher and improves its setup.