### PR TITLE
_check_recache: set _custom to not call set_source_attributes always

### DIFF
--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -207,3 +207,4 @@ class Deoplete(logger.LoggingMixin):
                 self.on_event(context)
         elif context['custom'] != self._custom:
             self._set_source_attributes(context)
+            self._custom = context['custom']


### PR DESCRIPTION
Not sure if/why this is needed after all, but at least it should update `self._custom`, which appears to be only used for this check.