### PR TITLE
Deoplete.__init__: fall back to single process

### DIFF
--- a/rplugin/python3/deoplete/deoplete.py
+++ b/rplugin/python3/deoplete/deoplete.py
@@ -30,8 +30,10 @@ class Deoplete(logger.LoggingMixin):
                                            'num_processes')
 
         if self._max_parents != 1 and not hasattr(self._vim, 'loop'):
-            error(self._vim, 'neovim-python 0.2.4+ is required.')
-            return
+            msg = ('neovim-python 0.2.4+ is required for %d parents. '
+                   'Using single process.' % self._max_parents)
+            error(self._vim, msg)
+            self._max_parents = 1
 
         # Enable logging for more information, and e.g.
         # deoplete-jedi picks up the log filename from deoplete's handler in


### PR DESCRIPTION
This situation can be handled easily, no need to stop working because of
it.