### PR TITLE
Split Parent into SingleParent/MultiParent

### DIFF
--- a/rplugin/python3/deoplete/process.py
+++ b/rplugin/python3/deoplete/process.py
@@ -14,10 +14,11 @@ class Process(asyncio.SubprocessProtocol):
         self._vim = plugin._vim
 
     def connection_made(self, transport):
-        self._plugin._stdin = transport.get_pipe_transport(0)
+        self._unpacker = self._plugin._connect_stdin(
+            transport.get_pipe_transport(0))
 
     def pipe_data_received(self, fd, data):
-        unpacker = self._plugin._unpacker
+        unpacker = self._unpacker
         unpacker.feed(data)
         for child_out in unpacker:
             self._plugin._queue_out.put(child_out)


### PR DESCRIPTION
This cleans up responsibilities between code, and makes it easier to
grasp what gets done in what case.

This also avoids passing `context` to `Parent` to get the number of
processes from it.

I've also removed the `cwd=context['cwd']` with
`self._vim.loop.subprocess_exec` for MultiParent - assuming that it will
default to the current one.
If that assumption is wrong it should be fixed for
`SingleParent`/`Child` then also/instead.