### PR TITLE
Do not trigger <c-e> for already visible pum

### DIFF
--- a/autoload/deoplete/mapping.vim
+++ b/autoload/deoplete/mapping.vim
@@ -5,8 +5,7 @@
 "=============================================================================
 
 function! deoplete#mapping#_init() abort
-  " Note: The dummy function is needed for cpoptions bug in neovim
-  inoremap <expr><silent> <Plug>_ deoplete#mapping#_dummy_complete()
+  inoremap <expr><silent> <Plug>_ "\<C-r>=deoplete#mapping#_complete()\<CR>"
 endfunction
 
 function! deoplete#mapping#_completefunc(findstart, base) abort
@@ -15,10 +14,6 @@ function! deoplete#mapping#_completefunc(findstart, base) abort
   else
     return g:deoplete#_context.candidates
   endif
-endfunction
-function! deoplete#mapping#_dummy_complete() abort
-  return (pumvisible() ? "\<C-e>" : '')
-        \ . "\<C-r>=deoplete#mapping#_complete()\<CR>"
 endfunction
 function! deoplete#mapping#_complete() abort
   call complete(g:deoplete#_context.complete_position + 1,


### PR DESCRIPTION
It was added in d8a8670 [1], without any comment/reference.

This fixes an issue, where deoplete reverts an already selected item from
the popup menu (using normal `<C-p>`), when new completions arrive.

In my case the later completions are coming from deoplete-jedi (slower),
but it can also be reproduced with the around source:

Given:

    $shims_base_dir
    $shims_

Place the cursor in the 2nd line, type `A` and `Ctrl-P` fast: The Ctrl-P
will select `$shims_base_dir` then.
When deoplete sets the completions `$shims_` gets added additionally (which is a bug
in the around source it seems).

With this change `$shims_` will show up shortly in the completion list,
but `$shims_base_dir` will still be inserted/selected.

This is obviously caused by the `<C-e>` that deoplete sends itself, and
should not be necessary at all.

This also removes the `deoplete#mapping#_dummy_complete` wrapper.

I could not reproduce https://github.com/Shougo/deoplete.nvim/issues/769
with `set cpoptions=c`.  Maybe it was related to the conditional that
was used before (see 86eeb17).

1: https://github.com/Shougo/deoplete.nvim/commit/d8a8670