### PR TITLE
Remove configuration samples anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Here are some [completion sources](https://github.com/Shougo/deoplete.nvim/wiki/
   - [Requirements](#requirements)
 - [Configuration](#configuration)
 - [Screenshots](#screenshots)
-- [Configuration samples](#configuration-samples)
 
 <!-- vim-markdown-toc -->
 


### PR DESCRIPTION
forgot to remove with [this commit](https://github.com/Shougo/deoplete.nvim/commit/62078d04aea43aceb7cbdcfc4b22cf8f7767f614)