### PR TITLE
Correct event handling of 'buffer' source

### DIFF
--- a/autoload/deoplete/handler.vim
+++ b/autoload/deoplete/handler.vim
@@ -12,7 +12,7 @@ function! deoplete#handler#_init() abort
     autocmd InsertLeave * call s:completion_timer_stop()
   augroup END
 
-  for event in ['InsertEnter', 'BufWritePost']
+  for event in ['InsertEnter', 'BufReadPost', 'BufWritePost']
     call s:define_on_event(event)
   endfor
 

--- a/rplugin/python3/deoplete/source/buffer.py
+++ b/rplugin/python3/deoplete/source/buffer.py
@@ -16,7 +16,7 @@ class Source(Base):
 
         self.name = 'buffer'
         self.mark = '[B]'
-        self.events = ['InsertEnter', 'BufWritePost']
+        self.events = ['BufReadPost', 'BufWritePost']
         self.vars = {
             'require_same_filetype': True,
         }
@@ -26,13 +26,9 @@ class Source(Base):
         self._max_lines = 5000
 
     def on_event(self, context):
-        if (context['bufnr'] not in self._buffers
-                or context['event'] == 'BufWritePost'):
-            self._make_cache(context)
+        self._make_cache(context)
 
     def gather_candidates(self, context):
-        self.on_event(context)
-
         tab_bufnrs = self.vim.call('tabpagebuflist')
         same_filetype = self.get_var('require_same_filetype')
         return {'sorted_candidates': [


### PR DESCRIPTION
The 'buffer' source currently has some non-obvious behaviour. It refreshes the cache for a given buffer when writing it to a file and on `InsertEnter`. The last thing happens only when there is no cache for buffer before. As the buffer caches get never invalidated, essentially the `InsertEnter` event hook only works at most once during a session.

All the above means, that the cache for a buffer is never populated if the buffer gets never modified. If you have lots of buffers open and want to edit only a single file, you don't get any meaningful completions.

I changed the behaviour as follows:

1.  Add a new autocmd hook for `BufReadPost`.
2. Refresh the cache for a buffer unconditionally on `BufReadPost` and `BufWritePost` and don't hook other events.

This results in having the buffer source providing completions for the on-disk state of every open buffer which is what the average user would expect :)