### PR TITLE
Enabled convert2candidates() to handle lists which have str and dict …

### DIFF
--- a/rplugin/python3/deoplete/util.py
+++ b/rplugin/python3/deoplete/util.py
@@ -24,8 +24,16 @@ def convert2list(expr):
 
 
 def convert2candidates(l):
-    return ([{'word': x} for x in l]
-            if l and isinstance(l, list) and isinstance(l[0], str) else l)
+    ret = []
+    if l and isinstance(l, list):
+        for x in l:
+            if isinstance(x, str):
+                ret.append({'word': x})
+            else:
+                ret.append(x)
+    else:
+        ret = l
+    return ret
 
 
 def globruntime(runtimepath, path):


### PR DESCRIPTION
Some plugin's "omnifunc" returns candidates which has both str and dict in a list.
e.g.) https://github.com/othree/csscomplete.vim

In such a case, deoplete shows error like following:

[deoplete] Traceback (most recent call last):
  File "C:/Users/ishitaku/.vim/plugged/deoplete.nvim/rplugin/python3\deoplete\child.py", line 220, in _gather_results
    ctx['candidates'] = source.gather_candidates(ctx)
  File "C:\Users\ishitaku\.vim\plugged\deoplete.nvim\rplugin\python3\deoplete\source\omni.py", line 94, in gather_candidates
    candidate['dup'] = 1
TypeError: 'str' object does not support item assignment
Error from omni: TypeError("'str' object does not support item assignment",).  Use :messages / see above for error details.

This commit enable to manage lists of mixed candidates.