### PR TITLE
README: Add check for vim 8+ in vim-plug instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ For vim-plug
 if has('nvim')
   Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }
 else
-  Plug 'Shougo/deoplete.nvim'
-  Plug 'roxma/nvim-yarp'
-  Plug 'roxma/vim-hug-neovim-rpc'
+  if v:version >= 800
+    Plug 'Shougo/deoplete.nvim'
+    Plug 'roxma/nvim-yarp'
+    Plug 'roxma/vim-hug-neovim-rpc'
+  endif
 endif
-let g:deoplete#enable_at_startup = 1
 ```
 
 For dein.vim


### PR DESCRIPTION
This way you can use a dotfiles that works on older versions of vim