### PR TITLE
Improve document consistency and clarity

### DIFF
--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -104,27 +104,27 @@ The set of available options follows.
 async_timeout
 		The timeout of asynchronous completion.
 
-		Default: 150
+		Default value: 150 (miliseconds)
 
 					*deoplete-options-auto_complete*
 auto_complete
 		If it is False, automatic completion becomes invalid, but can
 		use the manual completion by |deoplete#manual_complete()|.
 
-		Default: v:true
+		Default value: true
 
 					*deoplete-options-auto_complete_delay*
 auto_complete_delay
 		Delay the completion after input in milliseconds.
 
-		Default value: 20
+		Default value: 20 (miliseconds)
 
 					*deoplete-options-auto_refresh_delay*
 auto_refresh_delay
 		Delay the refresh when asynchronous.
 		If it is less than equal 0, the feature is disabled.
 
-		Default value: 50
+		Default value: 50 (miliseconds)
 
 						*deoplete-options-camel_case*
 camel_case
@@ -135,7 +135,7 @@ camel_case
 		|deoplete-filter-matcher_fuzzy| or
 		|deoplete-filter-matcher_full_fuzzy|.
 
-		Default value: v:false
+		Default value: false
 
 					*deoplete-options-complete_method*
 complete_method
@@ -226,14 +226,14 @@ on_insert_enter
 		Deoplete enables the auto completion on |InsertEnter| autocmd
 		if this value is True.
 
-		Default value: v:true
+		Default value: true
 
 					*deoplete-options-on_text_changed_i*
 on_text_changed_i
 		Deoplete enables the auto completion on |TextChangedI| autocmd
 		if this value is True.
 
-		Default value: v:true
+		Default value: true
 
 						*deoplete-options-profile*
 profile
@@ -242,7 +242,7 @@ profile
 		Must be set in init.vim/vimrc before starting Neovim/Vim.
 		Does not support command line.
 
-		Default value: v:false
+		Default value: false
 
 					*deoplete-options-refresh_always*
 refresh_always
@@ -250,7 +250,7 @@ refresh_always
 		is True.
 		Note: It increases the screen flicker.
 
-		Default value: v:true
+		Default value: true
 
 						*deoplete-options-skip_chars*
 skip_chars
@@ -297,7 +297,7 @@ yarp
 		Note: nvim-yarp plugin is needed.
 		https://github.com/roxma/nvim-yarp
 
-		Default value: v:false
+		Default value: false
 
 ------------------------------------------------------------------------------
 VARIABLES	 					*deoplete-variables*


### PR DESCRIPTION
I was reading the documentation with `:help deoplete-optiosn`, as a new user, and found some inconsistency issues and unknown units.