### PR TITLE
fixing file path completion when used with NERDTree

### DIFF
--- a/rplugin/python3/deoplete/source/file.py
+++ b/rplugin/python3/deoplete/source/file.py
@@ -85,8 +85,9 @@ class Source(Base):
     def _substitute_path(self, context, path):
         m = re.match(r'(\.{1,2})/+', path)
         if m:
-            if self.get_var('enable_buffer_path') and context['bufpath']:
-                base = context['bufpath']
+            if self.get_var('enable_buffer_path'):  # and context['bufpath']:
+                base = self.vim.current.buffer.name
+                # print(base)
             else:
                 base = os.path.join(context['cwd'], 'x')
 


### PR DESCRIPTION
When used with NERDTree, filepath completion goes to the root of selected NERDTree directory instead of current buffer's filepath
