### PR TITLE
Update around source to accept custom values

### DIFF
--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -532,9 +532,30 @@ around						    *deoplete-source-around*
 
 		Legend: You can see where the words came from. Next to the
 		source mark [~] these suffixes are used:
-		    A - above the cursor
-		    B - below the cursor
-		    C - in changes
+		    A - above the cursor 
+		    B - below the cursor 
+		    C - in changes       
+
+		By default, around has a fixed range of looking for words
+		20 lines above and below your cursor position. You are able
+		to customize its settings through custom source variables.
+		Note: There are no events for changing this. Configuration
+		should be done before the source initializes.
+>
+		" Using custom variables to configure values
+		" - range_above = Search for words N lines above.
+		" - range_below = Search for words N lines below.
+		" - mark_above = Mark shown for words N lines above.
+		" - mark_below = Mark shown for words N lines below.
+		" - mark_changes = Mark shown for words in the changelist.
+		call deoplete#custom#var('around', {
+		\   'range_above': 15,
+		\   'range_below': 15
+		\   'mark_above': '[↑]',
+		\   'mark_below': '[↓]',
+		\   'mark_changes': '[*]',
+		\})
+<
 
 		rank: 300
 

--- a/rplugin/python3/deoplete/source/around.py
+++ b/rplugin/python3/deoplete/source/around.py
@@ -22,7 +22,9 @@ class Source(Base):
             'range_above': 20,
             'range_below': 20,
         }
-        custom_vars = self.vim.call('deoplete#custom#_get_source_vars', self.name)
+        custom_vars = self.vim.call(
+            'deoplete#custom#_get_source_vars', self.name
+        )
         if custom_vars:
             self.vars.update(custom_vars)
 
@@ -33,11 +35,15 @@ class Source(Base):
         # lines above
         words = parse_buffer_pattern(
             reversed(
-                getlines(self.vim, max([1, line - self.vars['range_above']]), line)
+                getlines(
+                    self.vim, max([1, line - self.vars['range_above']]), line
+                )
             ),
             context['keyword_pattern'],
         )
-        candidates += [{'word': x, 'menu': self.vars['mark_above']} for x in words]
+        candidates += [
+            {'word': x, 'menu': self.vars['mark_above']} for x in words
+        ]
 
         # grab ':changes' command output
         p = re.compile(r'[\s\d]+')
@@ -51,13 +57,17 @@ class Source(Base):
                 lines.add(change_line)
 
         words = parse_buffer_pattern(lines, context['keyword_pattern'])
-        candidates += [{'word': x, 'menu': self.vars['mark_changes']} for x in words]
+        candidates += [
+            {'word': x, 'menu': self.vars['mark_changes']} for x in words
+        ]
 
         # lines below
         words = parse_buffer_pattern(
             getlines(self.vim, line, line + self.vars['range_below']),
             context['keyword_pattern'],
         )
-        candidates += [{'word': x, 'menu': self.vars['mark_below']} for x in words]
+        candidates += [
+            {'word': x, 'menu': self.vars['mark_below']} for x in words
+        ]
 
         return candidates

--- a/rplugin/python3/deoplete/source/around.py
+++ b/rplugin/python3/deoplete/source/around.py
@@ -13,51 +13,51 @@ from deoplete.util import parse_buffer_pattern, getlines
 class Source(Base):
     def __init__(self, vim):
         super().__init__(vim)
-        self.name = "around"
+        self.name = 'around'
         self.rank = 300
         self.vars = {
-            "mark_above": "[A]",
-            "mark_below": "[B]",
-            "mark_changes": "[C]",
-            "range_above": 20,
-            "range_below": 20,
+            'mark_above': '[A]',
+            'mark_below': '[B]',
+            'mark_changes': '[C]',
+            'range_above': 20,
+            'range_below': 20,
         }
-        custom_vars = self.vim.call("deoplete#custom#_get_source_vars", self.name)
+        custom_vars = self.vim.call('deoplete#custom#_get_source_vars', self.name)
         if custom_vars:
             self.vars.update(custom_vars)
 
     def gather_candidates(self, context):
-        line = context["position"][1]
+        line = context['position'][1]
         candidates = []
 
         # lines above
         words = parse_buffer_pattern(
             reversed(
-                getlines(self.vim, max([1, line - self.vars["range_above"]]), line)
+                getlines(self.vim, max([1, line - self.vars['range_above']]), line)
             ),
-            context["keyword_pattern"],
+            context['keyword_pattern'],
         )
-        candidates += [{"word": x, "menu": self.vars["mark_above"]} for x in words]
+        candidates += [{'word': x, 'menu': self.vars['mark_above']} for x in words]
 
         # grab ':changes' command output
-        p = re.compile(r"[\s\d]+")
+        p = re.compile(r'[\s\d]+')
         lines = set()
         for change_line in [
             x[p.search(x).span()[1]:]
-            for x in self.vim.call("execute", "changes").split("\n")[2:]
+            for x in self.vim.call('execute', 'changes').split('\n')[2:]
             if p.search(x)
         ]:
-            if change_line and change_line != "-invalid-":
+            if change_line and change_line != '-invalid-':
                 lines.add(change_line)
 
-        words = parse_buffer_pattern(lines, context["keyword_pattern"])
-        candidates += [{"word": x, "menu": self.vars["mark_changes"]} for x in words]
+        words = parse_buffer_pattern(lines, context['keyword_pattern'])
+        candidates += [{'word': x, 'menu': self.vars['mark_changes']} for x in words]
 
         # lines below
         words = parse_buffer_pattern(
-            getlines(self.vim, line, line + self.vars["range_below"]),
-            context["keyword_pattern"],
+            getlines(self.vim, line, line + self.vars['range_below']),
+            context['keyword_pattern'],
         )
-        candidates += [{"word": x, "menu": self.vars["mark_below"]} for x in words]
+        candidates += [{'word': x, 'menu': self.vars['mark_below']} for x in words]
 
         return candidates

--- a/rplugin/python3/deoplete/source/around.py
+++ b/rplugin/python3/deoplete/source/around.py
@@ -9,16 +9,23 @@ import re
 from deoplete.source.base import Base
 from deoplete.util import parse_buffer_pattern, getlines
 
-LINES_ABOVE = 20
-LINES_BELOW = 20
-
 
 class Source(Base):
     def __init__(self, vim):
         super().__init__(vim)
         self.name = 'around'
-        self.mark = '[~]'
+        self.events = ['Init']
         self.rank = 300
+        self.vars = {
+            'mark_above': '[A]',
+            'mark_below': '[B]',
+            'mark_changes': '[C]',
+            'range_above': 20,
+            'range_below': 20
+        }
+
+    def on_event(self, context):
+        self.vars = self.get_filetype_var('_', '_')
 
     def gather_candidates(self, context):
         line = context['position'][1]
@@ -26,9 +33,8 @@ class Source(Base):
 
         # lines above
         words = parse_buffer_pattern(
-            reversed(getlines(self.vim, max([1, line - LINES_ABOVE]), line)),
-            context['keyword_pattern'])
-        candidates += [{'word': x, 'menu': 'A'} for x in words]
+            reversed(getlines(self.vim, max([1, line - self.vars['range_above']]), line)), context['keyword_pattern'])
+        candidates += [{'word': x, 'menu': self.vars['mark_above']} for x in words]
 
         # grab ':changes' command output
         p = re.compile(r'[\s\d]+')
@@ -41,12 +47,12 @@ class Source(Base):
                 lines.add(change_line)
 
         words = parse_buffer_pattern(lines, context['keyword_pattern'])
-        candidates += [{'word': x, 'menu': 'C'} for x in words]
+        candidates += [{'word': x, 'menu': self.vars['mark_changes']} for x in words]
 
         # lines below
         words = parse_buffer_pattern(
-            getlines(self.vim, line, line + LINES_BELOW),
+            getlines(self.vim, line, line + self.vars['range_below']),
             context['keyword_pattern'])
-        candidates += [{'word': x, 'menu': 'B'} for x in words]
+        candidates += [{'word': x, 'menu': self.vars['mark_below']} for x in words]
 
         return candidates

--- a/rplugin/python3/deoplete/source/around.py
+++ b/rplugin/python3/deoplete/source/around.py
@@ -13,46 +13,51 @@ from deoplete.util import parse_buffer_pattern, getlines
 class Source(Base):
     def __init__(self, vim):
         super().__init__(vim)
-        self.name = 'around'
-        self.events = ['Init']
+        self.name = "around"
         self.rank = 300
         self.vars = {
-            'mark_above': '[A]',
-            'mark_below': '[B]',
-            'mark_changes': '[C]',
-            'range_above': 20,
-            'range_below': 20
+            "mark_above": "[A]",
+            "mark_below": "[B]",
+            "mark_changes": "[C]",
+            "range_above": 20,
+            "range_below": 20,
         }
-
-    def on_event(self, context):
-        self.vars = self.get_filetype_var('_', '_')
+        custom_vars = self.vim.call("deoplete#custom#_get_source_vars", self.name)
+        if custom_vars:
+            self.vars.update(custom_vars)
 
     def gather_candidates(self, context):
-        line = context['position'][1]
+        line = context["position"][1]
         candidates = []
 
         # lines above
         words = parse_buffer_pattern(
-            reversed(getlines(self.vim, max([1, line - self.vars['range_above']]), line)), context['keyword_pattern'])
-        candidates += [{'word': x, 'menu': self.vars['mark_above']} for x in words]
+            reversed(
+                getlines(self.vim, max([1, line - self.vars["range_above"]]), line)
+            ),
+            context["keyword_pattern"],
+        )
+        candidates += [{"word": x, "menu": self.vars["mark_above"]} for x in words]
 
         # grab ':changes' command output
-        p = re.compile(r'[\s\d]+')
+        p = re.compile(r"[\s\d]+")
         lines = set()
         for change_line in [
-                x[p.search(x).span()[1]:] for x
-                in self.vim.call('execute', 'changes').split('\n')[2:]
-                if p.search(x)]:
-            if change_line and change_line != '-invalid-':
+            x[p.search(x).span()[1]:]
+            for x in self.vim.call("execute", "changes").split("\n")[2:]
+            if p.search(x)
+        ]:
+            if change_line and change_line != "-invalid-":
                 lines.add(change_line)
 
-        words = parse_buffer_pattern(lines, context['keyword_pattern'])
-        candidates += [{'word': x, 'menu': self.vars['mark_changes']} for x in words]
+        words = parse_buffer_pattern(lines, context["keyword_pattern"])
+        candidates += [{"word": x, "menu": self.vars["mark_changes"]} for x in words]
 
         # lines below
         words = parse_buffer_pattern(
-            getlines(self.vim, line, line + self.vars['range_below']),
-            context['keyword_pattern'])
-        candidates += [{'word': x, 'menu': self.vars['mark_below']} for x in words]
+            getlines(self.vim, line, line + self.vars["range_below"]),
+            context["keyword_pattern"],
+        )
+        candidates += [{"word": x, "menu": self.vars["mark_below"]} for x in words]
 
         return candidates


### PR DESCRIPTION
Following https://github.com/Shougo/deoplete.nvim/commit/8de398d09ac60d31cf070ede5bef56719929d543 it's now possible to grab user-defined settings without breaking for people who use default values. Through dictionary initialization:

```vim
call deoplete#custom#var('around', {
\   'mark_above': '[~]',
\   'mark_below': '[~]',
\   'mark_changes': '[~]',
\   'range_above': 12,
\   'range_below': 12
\})
```

Missing
- Tests (?)
- Documentation - I can add after your approval!