### PR TITLE
Removed print() messages

### DIFF
--- a/rplugin/python3/deoplete/child.py
+++ b/rplugin/python3/deoplete/child.py
@@ -365,8 +365,6 @@ class Child(logger.LoggingMixin):
             ctx['candidates'] = source.on_post_filter(ctx)
 
         mark = source.mark + ' '
-        print(source.name)
-        print(ctx['candidates'])
         for candidate in ctx['candidates']:
             # Set default menu and icase
             candidate['icase'] = 1


### PR DESCRIPTION
Python's print() messages has now been displayed in `:messages` since ec014e3a8d53b7bbc8a3906013975157d09936a1 was committed.
If this is unintended behavior, please merge.