### PR TITLE
vimoption2python no longer creates ambiguous regex syntax

### DIFF
--- a/autoload/deoplete/util.vim
+++ b/autoload/deoplete/util.vim
@@ -68,6 +68,13 @@ function! s:vimoption2python(option) abort
     elseif pattern ==# '-'
       let has_dash = 1
     else
+      " Avoid ambiguous Python 3 RE syntax for nested sets
+      if pattern =~# '^--'
+        let pattern = '\' . pattern
+      elseif pattern =~# '--$'
+        let pattern = split(pattern, '-')[0] . '-\-'
+      endif
+
       call add(patterns, pattern)
     endif
   endfor

--- a/test/autoload/deoplete/util.vim
+++ b/test/autoload/deoplete/util.vim
@@ -27,4 +27,9 @@ function! s:suite.vimoption2python() abort
   call s:assert.equals(
         \ deoplete#util#vimoption2python('45,48-57,65-90,95,97-122'),
         \ '[\w0-9A-Z_a-z-]')
+  call s:assert.equals(
+        \ deoplete#util#vimoption2python('33,35-39,42-43,45-58,60-90,94,95,97-122,126'),
+        \ '[\w!#-''*-+\--:<-Z^_a-z~]')
+  call s:assert.equals(
+        \ deoplete#util#vimoption2python('33-45'), '[\w!-\-]')
 endfunction


### PR DESCRIPTION
Python 3.7+ makes it so that a `FutureWarning` notice is printed whenever a regular expression is compiled that contains a sequence which might become ambiguous [if nested set operations are added](https://docs.python.org/3/library/re.html#index-12).

There are some cases where Deoplete's `vimoption2python` function could produce such a sequence when generating a Python regex for the plugin code to use. In particular, I found this happened from the [built-in scheme filetype](https://github.com/neovim/neovim/blob/master/runtime/ftplugin/scheme.vim).

The `iskeyword` setting for Scheme is `33,35-39,42-43,45-58,60-90,94,95,97-122,126` which is converted by `vimoptions2python` into `[\w!#-'*-+--:<-Z^_a-z~]` (the issue is the 4th pattern which gets converted into `--:`).

The change in this PR inserts an additional check before adding a pattern to the list, to determine if it's a character range and either the beginning or end character in the range is `-`. If that is the case, we escape the literal hyphen (e.g. if the pattern was `!--` we would escape it to `!-\-` instead of `!\--`). I don't believe we will encounter the other ambiguous regex syntax cases in this code path.

All of that being said, I'm very unfamiliar with Vimscript so I would encourage a thorough review and consideration of any possible edge cases I've missed!