### PR TITLE
Fix deoplete#custom#source for max_info_width

### DIFF
--- a/rplugin/python3/deoplete/child.py
+++ b/rplugin/python3/deoplete/child.py
@@ -484,6 +484,7 @@ class Child(logger.LoggingMixin):
             'matchers',
             'max_abbr_width',
             'max_candidates',
+            'max_info_width',
             'max_kind_width',
             'max_menu_width',
             'max_pattern_length',


### PR DESCRIPTION
Setting e.g. `deoplete#custom#source('_', 'max_menu_width', 0)` would work as expected but setting either of:
- `deoplete#custom#source('_', 'max_info_width', 0)`
- `deoplete#custom#source('_', 'max_abbr_width', 0)`

...would be ignored by deoplete.

Fixes #968.