### PR TITLE
Use test/requirements.txt for pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,7 @@ export THEMIS_HOME := ./vim-themis
 
 
 install: vim-themis
-	pip install pynvim --upgrade
-	pip install pytest --upgrade
-	pip install flake8 --upgrade
-	pip install mypy --upgrade
-	pip install vim-vint --upgrade
-	pip install pytest-cov --upgrade
+	pip install --upgrade -r test/requirements.txt
 
 lint:
 	vint --version

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,6 @@
+pynvim
+pytest
+flake8
+mypy
+vim-vint
+pytest-cov


### PR DESCRIPTION
This allows to easily install it manually, and allows for later pinning
therein etc.
Also e.g. GitHub will detect this for projects being used for example
then.