### PR TITLE
ci: Travis: fix PYTEST_ADDOPTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 env:
   global:
     - PATH=$HOME/neovim/bin:$PATH
-    - PYTEST_ADDOPTS=--cov -rplugin/python3/deoplete
+    - PYTEST_ADDOPTS=--cov rplugin/python3/deoplete
 
 script:
   - make --keep-going test lint


### PR DESCRIPTION
The leading "-" turned this into the "-r" option, which happily consumed
all the following chars as reportchars then.