### PR TITLE
Remove 'mappings#' from the example

### DIFF
--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -516,7 +516,7 @@ deoplete#manual_complete([{sources}])
 		inoremap <silent><expr> <TAB>
 		\ pumvisible() ? "\<C-n>" :
 		\ <SID>check_back_space() ? "\<TAB>" :
-		\ deoplete#mappings#manual_complete()
+		\ deoplete#manual_complete()
 		function! s:check_back_space() abort "{{{
 		let col = col('.') - 1
 		return !col || getline('.')[col - 1]  =~ '\s'


### PR DESCRIPTION
`deoplete#mappings#manual_complete()` has changed to `deoplete#manual_complete()`
but its exapmle has not changed.