### PR TITLE
Handle non-existing g:deoplete#_python_version_check

### DIFF
--- a/autoload/deoplete/init.vim
+++ b/autoload/deoplete/init.vim
@@ -253,5 +253,5 @@ vim.vars['deoplete#_python_version_check'] = (
     sys.version_info.minor,
     sys.version_info.micro) < (3, 6, 1)
 EOF
-  return g:deoplete#_python_version_check
+  return get(g:, 'deoplete#_python_version_check', 0)
 endfunction


### PR DESCRIPTION
Fixes:

> E121: Undefined variable: g:deoplete#_python_version_check

When using a virtualenv and explicit python host config where "pynvim"
is not installed.  It would never set the variable then.