### PR TITLE
Prepare to support textEdit

### DIFF
--- a/autoload/deoplete/handler.vim
+++ b/autoload/deoplete/handler.vim
@@ -297,7 +297,12 @@ function! s:on_complete_done() abort
   call deoplete#handler#_skip_next_completion()
 
   if get(v:completed_item, 'user_data', '') !=# ''
-    call s:substitute_suffix(json_decode(v:completed_item.user_data))
+    try
+      if type(v:completed_item.user_data) == type('')
+        call s:substitute_suffix(json_decode(v:completed_item.user_data))
+      endif
+    catch /.*/
+    endtry
   endif
 endfunction
 function! s:substitute_suffix(user_data) abort


### PR DESCRIPTION
Hi, Thanks for provided deoplete.nvim.
I like deoplete because it's fast.

This PR aims to prepare to avoid conflicts to `user_data` from other plugin.

For example, When support completion-item's `textEdit` that defined in LSP spec, it is difficult maybe.

The reason is that deoplete cause error if `user_data` is not string.
(`vim-lsp` assign dictionary to `user_data`)

I don't know the reason why deoplete checks `user_data`.
I could not find the assignment to `user_data` by deoplete itself.