### PR TITLE
Fix docs regarding default converters

### DIFF
--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -716,6 +716,7 @@ Default sorters: ['sorter_rank'].
 
 					*deoplete-filter-converter_default*
 Default converters: ['converter_remove_overlap', 'converter_truncate_abbr',
+                     'converter_truncate_kind', 'converter_truncate_info',
                      'converter_truncate_menu'].
 
 	You can change it by |deoplete#custom#source()|.


### PR DESCRIPTION
Fixed documentation regarding default converters, as specified in rplugin/python3/deoplete/base/source.py