### PR TITLE
python version check logic was inverted. probably typo from denite code

### DIFF
--- a/autoload/health/deoplete.vim
+++ b/autoload/health/deoplete.vim
@@ -36,7 +36,7 @@ function! s:check_required_python_for_deoplete() abort
           \ )
   endif
 
-  if !deoplete#init#_python_version_check()
+  if deoplete#init#_python_version_check()
     call health#report_ok('Require Python3.6.1+ was successful')
   else
     call health#report_error(


### PR DESCRIPTION
seems like typo from denite code. logic inside #init#_python_version_check() differs