### PR TITLE
Remove `encoding` and `unicode_errors` option from Packer and Unpacker

### DIFF
--- a/rplugin/python3/deoplete/child.py
+++ b/rplugin/python3/deoplete/child.py
@@ -40,12 +40,9 @@ class Child(logger.LoggingMixin):
         self._source_errors: typing.Dict[str, int] = defaultdict(int)
         self._prev_results: typing.Dict[str, Result] = {}
         self._unpacker = msgpack.Unpacker(
-            encoding='utf-8',
             unicode_errors='surrogateescape')
         self._packer = msgpack.Packer(
-            use_bin_type=True,
-            encoding='utf-8',
-            unicode_errors='surrogateescape')
+            use_bin_type=True)
         self._ignore_sources: typing.List[typing.Any] = []
 
     def main_loop(self, stdout: typing.Any) -> None:

--- a/rplugin/python3/deoplete/parent.py
+++ b/rplugin/python3/deoplete/parent.py
@@ -118,11 +118,8 @@ class AsyncParent(_Parent):
         self._queue_out: Queue = Queue()  # type: ignore
         self._queue_err: Queue = Queue()  # type: ignore
         self._packer = msgpack.Packer(
-            use_bin_type=True,
-            encoding='utf-8',
-            unicode_errors='surrogateescape')
+            use_bin_type=True)
         self._unpacker = msgpack.Unpacker(
-            encoding='utf-8',
             unicode_errors='surrogateescape')
         self._prev_pos: typing.List[typing.Any] = []
 


### PR DESCRIPTION
Remove the `encoding` and `unicode_errors` option from `msgpack.Packer`,  and remove the `encoding` option from `msgpack.Unpacker`.
ref:
- msgpack/msgpack-python@e1ed004
- msgpack/msgpack-python@e419cd8

But both commits were 11 days ago and very recent commits (I've always `pip install git+http://...` so this problem occurred)

I don't know that can keep backward compatibility without that option, but this problem undoubtedly occurs when a new release of msgpack-python.
So, merge timing leaves you.