### PR TITLE
feat: add manual_menu option

### DIFF
--- a/autoload/deoplete.vim
+++ b/autoload/deoplete.vim
@@ -57,6 +57,7 @@ function! deoplete#manual_complete(...) abort
   call deoplete#init#_prev_completion()
 
   " Start complete.
+  let g:deoplete#_manual = v:true
   return "\<C-r>=deoplete#mapping#_rpcrequest_wrapper("
         \ . string(get(a:000, 0, [])) . ")\<CR>"
 endfunction

--- a/autoload/deoplete/handler.vim
+++ b/autoload/deoplete/handler.vim
@@ -82,6 +82,7 @@ function! deoplete#handler#_check_omnifunc(context) abort
         \ || index(blacklist, &l:omnifunc) >= 0
         \ || prev.input ==# a:context.input
         \ || s:check_input_method()
+        \ || deoplete#custom#_get_option('manual_menu') && !g:deoplete#_manual
     return
   endif
 
@@ -281,6 +282,7 @@ function! s:on_insert_leave() abort
 endfunction
 
 function! s:on_complete_done() abort
+  let g:deoplete#_manual = v:false
   if get(v:completed_item, 'word', '') ==# ''
     return
   endif

--- a/autoload/deoplete/init.vim
+++ b/autoload/deoplete/init.vim
@@ -113,6 +113,7 @@ function! s:init_internal_variables() abort
   call deoplete#init#_prev_completion()
 
   let g:deoplete#_context = {}
+  let g:deoplete#_manual = v:false
 
   if !exists('g:deoplete#_logging')
     let g:deoplete#_logging = {}
@@ -197,6 +198,9 @@ function! deoplete#init#_custom_variables() abort
   call s:check_custom_option(
         \ 'g:deoplete#enable_yarp',
         \ 'yarp')
+  call s:check_custom_option(
+        \ 'g:deoplete#manual_menu',
+        \ 'manual_menu')
 
   " Source variables
   call s:check_custom_var('file',
@@ -248,6 +252,7 @@ function! deoplete#init#_option() abort
         \ 'sources': {},
         \ 'trigger_key': v:char,
         \ 'yarp': v:false,
+        \ 'manual_menu': v:false,
         \ }
 endfunction
 function! deoplete#init#_prev_completion() abort

--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -184,6 +184,13 @@ keyword_patterns
 <
 		Default value: {}
 
+						*deoplete-options-manual_menu*
+manual_menu
+		Do not show completion popup menu until |deoplete#manual_complete()|
+		will be called.
+
+		Default value: v:false
+
 						*deoplete-options-max_list*
 max_list
 		Show up to this limit candidates.

--- a/rplugin/python3/deoplete/child.py
+++ b/rplugin/python3/deoplete/child.py
@@ -518,6 +518,12 @@ class Child(logger.LoggingMixin):
                 return False
         if context['event'] == 'Manual':
             return False
+
+        manual_menu = self._vim.call(
+            'deoplete#custom#_get_option', 'manual_menu')
+        if manual_menu and not self._vim.vars['deoplete#_manual']:
+            return True
+
         return not (source.min_pattern_length <=
                     len(context['complete_str']) <= source.max_pattern_length)
 


### PR DESCRIPTION
Closes #1065 

Example `vimrc` setup with extra feature to auto-insert first completion:
```vim
call deoplete#custom#option('manual_menu', v:true)

inoremap <silent><expr> <TAB>
    \ pumvisible() ? "\<C-n>" :
    \ <SID>check_back_space() ? "\<Tab>" :
    \ <SID>manual_complete()
function! s:check_back_space() abort
    let col = col('.') - 1
    return !col || getline('.')[col - 1]  =~# '\s'
endfunction
function! s:manual_complete()
    call timer_start(100, {-> feedkeys("\<C-n>", 'in')})
    return deoplete#manual_complete()
endfunction
```