### PR TITLE
Revert "Remove `encoding` and `unicode_errors` option from Packer and Unpacker"

### DIFF
--- a/rplugin/python3/deoplete/child.py
+++ b/rplugin/python3/deoplete/child.py
@@ -40,9 +40,12 @@ class Child(logger.LoggingMixin):
         self._source_errors: typing.Dict[str, int] = defaultdict(int)
         self._prev_results: typing.Dict[str, Result] = {}
         self._unpacker = msgpack.Unpacker(
+            encoding='utf-8',
             unicode_errors='surrogateescape')
         self._packer = msgpack.Packer(
-            use_bin_type=True)
+            use_bin_type=True,
+            encoding='utf-8',
+            unicode_errors='surrogateescape')
         self._ignore_sources: typing.List[typing.Any] = []
 
     def main_loop(self, stdout: typing.Any) -> None:

--- a/rplugin/python3/deoplete/parent.py
+++ b/rplugin/python3/deoplete/parent.py
@@ -118,8 +118,11 @@ class AsyncParent(_Parent):
         self._queue_out: Queue = Queue()  # type: ignore
         self._queue_err: Queue = Queue()  # type: ignore
         self._packer = msgpack.Packer(
-            use_bin_type=True)
+            use_bin_type=True,
+            encoding='utf-8',
+            unicode_errors='surrogateescape')
         self._unpacker = msgpack.Unpacker(
+            encoding='utf-8',
             unicode_errors='surrogateescape')
         self._prev_pos: typing.List[typing.Any] = []
 


### PR DESCRIPTION
Reverts Shougo/deoplete.nvim#1047

msgpack-python 1.0 is not released in pip and it breaks old msgpack-python.