### PR TITLE
Restore original 'word' in all candidates when using matcher_key

### DIFF
--- a/rplugin/python3/deoplete/child.py
+++ b/rplugin/python3/deoplete/child.py
@@ -354,16 +354,18 @@ class Child(logger.LoggingMixin):
         matchers = [self._filters[x] for x
                     in source.matchers if x in self._filters]
         if source.matcher_key != '':
+            original_candidates = ctx['candidates']
             # Convert word key to matcher_key
-            for candidate in ctx['candidates']:
+            for candidate in original_candidates:
                 candidate['__save_word'] = candidate['word']
                 candidate['word'] = candidate[source.matcher_key]
         for f in matchers:
             self._process_filter(f, ctx, source.max_candidates)
         if source.matcher_key != '':
             # Restore word key
-            for candidate in ctx['candidates']:
+            for candidate in original_candidates:
                 candidate['word'] = candidate['__save_word']
+                del candidate['__save_word']
 
         # Sort
         sorters = [self._filters[x] for x


### PR DESCRIPTION
Before this change, if you have a matcher_key in a source, and some candidates get filtered out, and the result is cached (so you don't have is_volatile=True) then you can end up in a situation where 'word' is not restored for all candidates. This can lead to the value of matcher_key being inserted, instead of the original value of 'word'.

The way to trigger this would be to type something with the matcher showing, delete some letters so other matches are being shown again, and then insert one of the matches that wasn't being showed when you had a longer string to match against. This match would then be inserted with the value of `matcher_key` instead of `word`.

I'm fixing it by storing the original list of candidates before they're filtered out by the matchers, so we can restore the value in all of them. I also added deletion of the `__save_word` value which isn't necessary, but just makes sure it's all cleaned up.