### PR TITLE
Add complete_suffix option

### DIFF
--- a/autoload/deoplete/handler.vim
+++ b/autoload/deoplete/handler.vim
@@ -322,7 +322,8 @@ function! s:on_complete_done() abort
   endif
 endfunction
 function! s:substitute_suffix(user_data) abort
-  if !has_key(a:user_data, 'old_suffix')
+  if !deoplete#custom#_get_option('complete_suffix')
+        \ || !has_key(a:user_data, 'old_suffix')
         \ || !has_key(a:user_data, 'new_suffix')
     return
   endif

--- a/autoload/deoplete/init.vim
+++ b/autoload/deoplete/init.vim
@@ -194,6 +194,9 @@ function! deoplete#init#_custom_variables() abort
         \ 'g:deoplete#enable_smart_case',
         \ 'smart_case')
   call s:check_custom_option(
+        \ 'g:deoplete#enable_complete_suffix',
+        \ 'complete_suffix')
+  call s:check_custom_option(
         \ 'g:deoplete#enable_yarp',
         \ 'yarp')
 
@@ -232,6 +235,7 @@ function! deoplete#init#_option() abort
         \ 'ignore_case': &ignorecase,
         \ 'ignore_sources': {},
         \ 'candidate_marks': [],
+        \ 'complete_suffix': v:true,
         \ 'max_list': 500,
         \ 'num_processes': 4,
         \ 'keyword_patterns': {'_': '[a-zA-Z_]\k*'},

--- a/doc/deoplete.txt
+++ b/doc/deoplete.txt
@@ -167,6 +167,13 @@ check_stderr
 
 		Default value: v:true
 
+					*deoplete-options-complete_suffix*
+complete_suffix
+		If it is True, deoplete inserts the suffix of the completion
+		for supported sources.  It is useful for deoplete-tabnine.
+
+		Default value: v:true
+
 						*deoplete-options-ignore_case*
 ignore_case
 		If it is True, deoplete ignores case.


### PR DESCRIPTION
Related to https://github.com/Shougo/deoplete.nvim/commit/3267781440f62dc5070d9a8a2d25d926b0266403 and https://github.com/tbodt/deoplete-tabnine/issues/26

This PR adds support for a new option to control the suffix completion which is currently used with deoplete-tabnine.  It maintains the default value of completing the suffix.