### PR TITLE
README has inverted logic for vim-plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ https://github.com/Shougo/deoplete.nvim/releases/tag/5.2
 For vim-plug
 
 ```viml
-if has('nvim')
+if !has('nvim')
   Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }
 else
   Plug 'Shougo/deoplete.nvim'


### PR DESCRIPTION
The README asks for nvim packages under vim-plug when nvim isn't running; or at least, this logic is inverted compared to the next block.