### PR TITLE
Use try-catch for pathlib.Path.expanduser

### DIFF
--- a/rplugin/python3/deoplete/util.py
+++ b/rplugin/python3/deoplete/util.py
@@ -216,7 +216,10 @@ def charwidth(c: str) -> int:
 
 def expand(path: str) -> str:
     if path.startswith('~'):
-        path = str(Path(path).expanduser())
+        try:
+            path = str(Path(path).expanduser())
+        except RuntimeError:
+            pass
     return expandvars(path)
 
 


### PR DESCRIPTION
Consider the following AWK script:
```awk
$1 ~ /regexp/
```

This is valid, but deoplete considers `~ ` as the home directory of user ` `, resulting in error:
```
[deoplete] Traceback (most recent call last):
  File "/usr/lib/python3.7/pathlib.py", line 375, in gethomedir
    return pwd.getpwnam(username).pw_dir
KeyError: "getpwnam(): name not found: ' '"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/deoplete.nvim/rplugin/python3/deoplete/child.py", line 203, in _gather_results
    result = self._get_result(context, source)
  File "/tmp/deoplete.nvim/rplugin/python3/deoplete/child.py", line 265, in _get_result
    ctx['candidates'] = source.gather_candidates(ctx)
  File "/tmp/deoplete.nvim/rplugin/python3/deoplete/source/file.py", line 59, in gather_candidates
    p = self._longest_path_that_exists(context, input_str)
  File "/tmp/deoplete.nvim/rplugin/python3/deoplete/source/file.py", line 91, in _longest_path_that_exists
    data))
  File "/tmp/deoplete.nvim/rplugin/python3/deoplete/source/file.py", line 90, in <lambda>
    lambda x: Path(self._substitute_path(context, x)).exists(),
  File "/tmp/deoplete.nvim/rplugin/python3/deoplete/source/file.py", line 97, in _substitute_path
    return expand(path)
  File "/tmp/deoplete.nvim/rplugin/python3/deoplete/util.py", line 219, in expand
    path = str(Path(path).expanduser())
  File "/usr/lib/python3.7/pathlib.py", line 1464, in expanduser
    homedir = self._flavour.gethomedir(self._parts[0][1:])
  File "/usr/lib/python3.7/pathlib.py", line 378, in gethomedir
    "for %r" % username)
RuntimeError: Can't determine home directory for ' '
Error from file: Can't determine home directory for ' '.  Use :messages / see above for error details.
```