### PR TITLE
added msgpack requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ https://github.com/Shougo/deoplete.nvim/releases/tag/5.2
 For vim-plug
 
 ```viml
+Plug 'msgpack/msgpack-python'
 if has('nvim')
   Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }
 else


### PR DESCRIPTION
When enabling the plugin via the current readme on GitHub, completion for files do not work.

After reading the docs in vim through `help deoplete` a new package `msgpack/msgpack-python` was required. Thus adding this information in the README.