### PR TITLE
Fix `input_patterns` source option not being recognised

### DIFF
--- a/rplugin/python3/deoplete/child.py
+++ b/rplugin/python3/deoplete/child.py
@@ -563,6 +563,7 @@ class Child(logger.LoggingMixin):
             'dup',
             'filetypes',
             'input_pattern',
+            'input_patterns',
             'is_debug_enabled',
             'is_silent',
             'is_volatile',


### PR DESCRIPTION
`input_pattern` is recognised, so I think `input_patterns` should be as well. The inability to set this source option from Vim config is really confusing when `input_pattern` can be set.

In particular, I needed to set a slightly different `input_pattern` for Haskell when using LanguageClient-neovim.