### PR TITLE
Installation using built-in package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ instead.
 
 https://github.com/Shougo/deoplete.nvim/releases/tag/5.2
 
-For vim-plug
+### vim-plug
 
 ```viml
 if has('nvim')
@@ -57,7 +57,7 @@ endif
 let g:deoplete#enable_at_startup = 1
 ```
 
-For dein.vim
+### dein.vim
 
 ```viml
 call dein#add('Shougo/deoplete.nvim')
@@ -68,7 +68,53 @@ endif
 let g:deoplete#enable_at_startup = 1
 ```
 
-For manual installation(not recommended)
+### Built-in Vim 8/NeoVim package manager (pack feature)
+
+Becasue Deoplete uses functions for configuration, we have to ensure it is loaded. So we put it as an *optional* package (`opt` subdirectory of your pack) and load it explicitly in the configuration file:
+
+#### Vim 8
+```
+git clone https://github.com/Shougo/deoplete.nvim ~/.vim/pack/dist/opt/deoplete.nvim
+```
+
+Generate helptags (optional):
+```
+:helptags ~/.vim/pack/dist/opt/deoplete.nvim/doc
+```
+
+#### NeoVim
+
+```
+git clone https://github.com/Shougo/deoplete.nvim ~/.config/nvim/pack/dist/opt/deoplete.nvim
+```
+
+Generate helptags (optional):
+```
+:helptags ~/.config/nvim/pack/dist/opt/deoplete.nvim/doc
+```
+
+#### Common configuration in `init.vim`/`.vimrc`
+
+```
+let g:deoplete#enable_at_startup = 1
+
+" This actually loads the plugin
+packadd deoplete.nvim
+
+" So here it's safe to call things like call deoplete#custom#option
+call deoplete#custom#option('ignore_sources', {'_': ['around', 'buffer']})
+```
+
+#### Generate the remote plugin manifest
+
+This is a very important step:
+```
+:UpdateRemotePlugins
+```
+
+And restart the editor for the plugin to start working.
+
+### Manual installation(not recommended)
 
 1. Extract the files and put them in your Neovim or .vim directory
    (usually `$XDG_CONFIG_HOME/nvim/`).


### PR DESCRIPTION
Vim 8 and NeoVim come with a [built-in package manager](https://vimhelp.org/repeat.txt.html#packages). However, the way it works is that it loads all the "auto-start" plugins _after_ loading the configuration file. So, Deoplete cannot be configured using the `deoplete#custom#option` function, as it's not available yet.

The solution is to make Deoplete an optional package and load it explicitly inside the configuration file.

This should prevent confusion like in https://github.com/Shougo/deoplete.nvim/issues/1152. Related issue: https://github.com/Shougo/deoplete.nvim/issues/990 (when not using _any_ package managers).

Thanks for your work on this great plugin!