### PR TITLE
Add missing negation in vim version validation

### DIFF
--- a/autoload/deoplete/init.vim
+++ b/autoload/deoplete/init.vim
@@ -49,7 +49,7 @@ function! deoplete#init#_channel() abort
     call deoplete#util#print_error('deoplete requires nvim 0.3.0+.')
     return 1
   endif
-  if !has('nvim') && has('patch-8.2.1978')
+  if !has('nvim') && !has('patch-8.2.1978')
     call deoplete#util#print_error('deoplete requires Vim 8.2.1978+.')
     return 1
   endif


### PR DESCRIPTION
Commit 610daca4 intended to elevate the vim version check. Unfortunately
the logic was reversed, effectively ensuring the opposite of what is
desired.