### PR TITLE
Suppress error message when no pattern matches

### DIFF
--- a/autoload/deoplete/mapping.vim
+++ b/autoload/deoplete/mapping.vim
@@ -18,7 +18,7 @@ function! deoplete#mapping#_init() abort
   noremap  <silent> <Plug>+  <Nop>
 endfunction
 function! deoplete#mapping#_dummy(func) abort
-  return "\<Cmd>call ".a:func."()\<CR>"
+  return "\<Cmd>silent call ".a:func."()\<CR>"
 endfunction
 function! s:check_completion_info(candidates) abort
   if !exists('*complete_info')


### PR DESCRIPTION
Commit f7b8364213e1c33164cbf97c5e1c7c5913bf0a97 changed the way the completion function is called, resulting in a "Pattern not found" and "Press enter or type command to continue" message when there were no matches. Calling the command silently fixes this.