### PR TITLE
Update path for cpsm_py module

### DIFF
--- a/rplugin/python3/deoplete/filter/matcher_cpsm.py
+++ b/rplugin/python3/deoplete/filter/matcher_cpsm.py
@@ -46,7 +46,7 @@ class Filter(Base):
 
     def _init_cpsm(self, context: UserContext) -> str:
         ext = '.pyd' if context['is_windows'] else '.so'
-        fname = 'bin/cpsm_py' + ext
+        fname = 'autoload/cpsm_py' + ext
         found = globruntime(self.vim.options['runtimepath'], fname)
         errmsg = ''
         if found:


### PR DESCRIPTION
I tried to use `matcher_cpsm` in deoplete.nvim, I found that https://github.com/nixprime/cpsm now install `cpsm_py.so` in `autoload` folder instead of `bin`.

Please help to review this PR, and merge it if it is helpful, thanks.